### PR TITLE
Unchecked Reticle Limit checkbox bypasses shot mapping

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -32,9 +32,9 @@ describe("App", () => {
 		await user.type(scribeLinesYInput, "0");
 
 		// How many 26mm x 33mm field shots can we fit in the panel?
-		const fielCountX = Math.ceil(300 / 26);
+		const fieldCountX = Math.ceil(300 / 26);
 		const fieldCountY = Math.ceil(300 / 33);
-		const fieldCount = fielCountX * fieldCountY;
+		const fieldCount = fieldCountX * fieldCountY;
 		// How many 5mm square dies can we fit in a single field shot?
 		const dieCountX = Math.floor(26 / 5);
 		const dieCountY = Math.floor(33 / 5);
@@ -179,7 +179,7 @@ describe("App", () => {
 		// Wait for validation error to appear
 		await waitFor(() => {
 			const errorText = screen.getByText(
-				new RegExp(`Die and scribe line width must be less than or equal to the field width \\(${defaultFieldWidth}mm\\)`, 'g')
+				new RegExp(`Die and scribe line width must be less than or equal to the field width \\(${defaultFieldWidth}mm\\)`)
 			);
 			expect(errorText).toBeInTheDocument();
 		});

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import App from "./App";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
+import { defaultFieldWidth, defaultFieldHeight } from "../config";
 
 describe("App", () => {
 	it("calculates the correct number of total 5mm dies on a 300mm panel with no scribe lines", async () => {
@@ -152,6 +153,76 @@ describe("App", () => {
 
 		// The total number of dies should be the number of dies per shot times the number of shots
 		expect(totalDies).toEqual(diePerReticle * shotCount);
+	});
+
+	it("enforces die size limits only when the Reticle Limit checkbox is checked", async () => {
+		render(<App />);
+		const user = userEvent.setup();
+
+		// Get the input elements and the Reticle Limit checkbox
+		const dieWidthInput = screen.getByRole("spinbutton", { name: /Width/ });
+		const dieHeightInput = screen.getByRole("spinbutton", { name: /Height/ });
+		const reticleLimitCheckbox = screen.getByRole("checkbox", {
+			name: new RegExp(`Reticle Limit \\(${defaultFieldWidth}mm x ${defaultFieldHeight}mm\\)`)
+		});
+
+		// By default, Reticle Limit should be checked
+		expect(reticleLimitCheckbox).toBeChecked();
+
+		// Try entering a die width larger than the field width
+		await user.clear(dieWidthInput);
+		await user.type(dieWidthInput, (defaultFieldWidth + 1).toString());
+
+		// Input should be clamped to the field width and show validation error
+		expect(dieWidthInput).toHaveDisplayValue(defaultFieldWidth.toString());
+
+		// Wait for validation error to appear
+		await waitFor(() => {
+			const errorText = screen.getByText(
+				new RegExp(`Die and scribe line width must be less than or equal to the field width \\(${defaultFieldWidth}mm\\)`, 'g')
+			);
+			expect(errorText).toBeInTheDocument();
+		});
+
+		// Uncheck the Reticle Limit checkbox
+		await user.click(reticleLimitCheckbox);
+		expect(reticleLimitCheckbox).not.toBeChecked();
+
+		// Now we should be able to enter larger die dimensions
+		await user.clear(dieWidthInput);
+		await user.type(dieWidthInput, (defaultFieldWidth + 10).toString());
+
+		// Input should accept the larger value
+		expect(dieWidthInput).toHaveDisplayValue((defaultFieldWidth + 10).toString());
+
+		// Wait for the validation error to disappear
+		await waitFor(() => {
+			// This looks for any validation error with the text containing "field width"
+			const errorText = screen.queryByText(/field width/i);
+			expect(errorText).not.toBeInTheDocument();
+		});
+
+		// Try a large height too
+		await user.clear(dieHeightInput);
+		await user.type(dieHeightInput, (defaultFieldHeight + 10).toString());
+
+		// Input should accept the larger value
+		expect(dieHeightInput).toHaveDisplayValue((defaultFieldHeight + 10).toString());
+
+		// Check the Reticle Limit checkbox again
+		await user.click(reticleLimitCheckbox);
+		expect(reticleLimitCheckbox).toBeChecked();
+
+		// Die dimensions should be clamped to field dimensions again
+		expect(dieWidthInput).toHaveDisplayValue(defaultFieldWidth.toString());
+		expect(dieHeightInput).toHaveDisplayValue(defaultFieldHeight.toString());
+
+		// And validation error should reappear
+		await waitFor(() => {
+			// We should see at least one validation error about field dimensions
+			const errorText = screen.getByText(/must be less than or equal to the field (width|height)/i);
+			expect(errorText).toBeInTheDocument();
+		});
 	});
 
 	describe("defects inputs", () => {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,9 @@
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, {
+	useState,
+	useEffect,
+	useRef,
+	useMemo,
+} from "react";
 import { Checkbox } from "./Checkbox/Checkbox";
 import { NumberInput } from "./NumberInput/NumberInput";
 import { useInputs } from "../hooks/useInputs";
@@ -134,24 +139,18 @@ function App() {
 			: waferSizes[waferSize].width;
 
 	const { width: fieldWidthMM, height: fieldHeightMM } = useMemo(() => {
-
 		if (!reticleLimit) {
 			return {
 				width: waferWidth,
 				height: waferHeight,
-			}
+			};
 		}
 
 		return {
 			width: defaultFieldWidth,
-			height: halfField ? defaultFieldHeight / 2 : defaultFieldHeight
+			height: halfField ? defaultFieldHeight / 2 : defaultFieldHeight,
 		};
-	}, [
-		reticleLimit,
-		halfField,
-		waferWidth,
-		waferHeight,
-	]);
+	}, [reticleLimit, halfField, waferWidth, waferHeight]);
 
 	const { results, validationError } = useInputs(
 		{
@@ -191,6 +190,15 @@ function App() {
 		}
 	}, [fieldHeightMM]);
 
+	useEffect(() => {
+		if (!reticleLimit) {
+			setShowShotMap(false);
+			setHalfField(false);
+		} else {
+			setShowShotMap(true);
+		}
+	}, [reticleLimit]);
+
 	const handleDieWidthChange = (value: string) => {
 		const inputValNum = parseFloat(value);
 
@@ -199,11 +207,19 @@ function App() {
 			return;
 		}
 
-		const clampedWidth = clampedInputDisplayValue(value, minDieEdge, fieldWidthMM);
+		const clampedWidth = clampedInputDisplayValue(
+			value,
+			minDieEdge,
+			fieldWidthMM,
+		);
 		setDieWidth(clampedWidth);
 
 		if (maintainAspectRatio) {
-			const clampedHeight = clampedInputDisplayValue(clampedWidth, minDieEdge, fieldHeightMM);
+			const clampedHeight = clampedInputDisplayValue(
+				clampedWidth,
+				minDieEdge,
+				fieldHeightMM,
+			);
 			setDieHeight(clampedHeight);
 		}
 	};
@@ -216,11 +232,19 @@ function App() {
 			return;
 		}
 
-		const clampedHeight = clampedInputDisplayValue(value, minDieEdge, fieldHeightMM);
+		const clampedHeight = clampedInputDisplayValue(
+			value,
+			minDieEdge,
+			fieldHeightMM,
+		);
 		setDieHeight(clampedHeight);
 
 		if (maintainAspectRatio) {
-			const clampedWidth = clampedInputDisplayValue(clampedHeight, minDieEdge, fieldHeightMM);
+			const clampedWidth = clampedInputDisplayValue(
+				clampedHeight,
+				minDieEdge,
+				fieldHeightMM,
+			);
 			setDieWidth(clampedWidth);
 		}
 	};
@@ -273,7 +297,7 @@ function App() {
 		event: React.ChangeEvent<HTMLInputElement>,
 	) => {
 		setShowReticleBackground(event.target.checked);
-	}
+	};
 
 	const handleHalfFieldChange = (
 		event: React.ChangeEvent<HTMLInputElement>,
@@ -334,7 +358,7 @@ function App() {
 						<Checkbox
 							label="Half Field Exposures (High NA)"
 							onChange={handleHalfFieldChange}
-							checked={reticleLimit ? halfField : false}
+							checked={halfField}
 							disabled={!reticleLimit}
 						/>
 					</div>
@@ -409,62 +433,56 @@ function App() {
 							}
 						/>
 					</div>
-					{
-						selectedModel !== 'manual' && (
-							<>
-								<div className="input-row">
-									<Checkbox
-										label="All Die Area Critical"
-										onChange={handleAllCriticalChange}
-										checked={allCritical}
-									/>
-								</div>
-								<div className="input-row">
-									<NumberInput
-										label="Critical Die Area (mm²)"
-										value={criticalArea}
-										isDisabled={allCritical}
-										onChange={(event) => setCriticalArea(event.target.value)}
-										max={parseFloat(criticalArea)}
-									/>
-								</div>
-								<div className="input-row">
-									<NumberInput
-										label="Defect Rate (#/cm²)"
-										value={defectRate}
-										min={0}
-										onChange={(event) => setDefectRate(event.target.value)}
-									/>
-								</div>
-							</>
-						)
-					}
-					{
-						selectedModel === 'bose-einstein' && (
+					{selectedModel !== "manual" && (
+						<>
 							<div className="input-row">
-								<NumberInput
-									label="Critical Layers"
-									value={criticalLayers}
-									onChange={(event) => setCriticalLayers(event.target.value)}
-									min={0}
-									max={100}
+								<Checkbox
+									label="All Die Area Critical"
+									onChange={handleAllCriticalChange}
+									checked={allCritical}
 								/>
 							</div>
-						)
-					}
-					{
-						selectedModel === 'manual' && (
 							<div className="input-row">
 								<NumberInput
-									label="Yield (%)"
-									value={manualYield}
-									onChange={(event) => setManualYield(event.target.value)}
-									min={0}
-									max={100}
+									label="Critical Die Area (mm²)"
+									value={criticalArea}
+									isDisabled={allCritical}
+									onChange={(event) => setCriticalArea(event.target.value)}
+									max={parseFloat(criticalArea)}
 								/>
 							</div>
-						)
-					}
+							<div className="input-row">
+								<NumberInput
+									label="Defect Rate (#/cm²)"
+									value={defectRate}
+									min={0}
+									onChange={(event) => setDefectRate(event.target.value)}
+								/>
+							</div>
+						</>
+					)}
+					{selectedModel === "bose-einstein" && (
+						<div className="input-row">
+							<NumberInput
+								label="Critical Layers"
+								value={criticalLayers}
+								onChange={(event) => setCriticalLayers(event.target.value)}
+								min={0}
+								max={100}
+							/>
+						</div>
+					)}
+					{selectedModel === "manual" && (
+						<div className="input-row">
+							<NumberInput
+								label="Yield (%)"
+								value={manualYield}
+								onChange={(event) => setManualYield(event.target.value)}
+								min={0}
+								max={100}
+							/>
+						</div>
+					)}
 					<JumpToResults outputRef={outputRef} />
 				</div>
 				<div className="output" ref={outputRef}>
@@ -487,6 +505,7 @@ function App() {
 							label="Show Reticle Shot Grid"
 							onChange={handleShowShotMapChange}
 							checked={showShotMap}
+							disabled={!reticleLimit}
 						/>
 						<hr />
 						<WaferStats
@@ -504,27 +523,30 @@ function App() {
 									? panelSizes[panelSize].height
 									: waferSizes[waferSize].width
 							}
+							reticleLimit={reticleLimit}
 						/>
 					</div>
-					<div className="panel">
-						<h2>Reticle Results</h2>
-						<ReticleCanvas
-							dieWidth={parseFloat(dieWidth)}
-							dieHeight={parseFloat(dieHeight)}
-							scribeHoriz={parseFloat(scribeHoriz)}
-							scribeVert={parseFloat(scribeVert)}
-							mmToPxScale={12}
-							showReticleBackground={showReticleBackground}
-							halfField={halfField}
-						/>
-						<Checkbox
-							label="Show Illustrative Background"
-							onChange={handleShowReticleBackgroundChange}
-							checked={showReticleBackground}
-						/>
-						<hr />
-						<ReticleStats results={easterEggEnabled ? null : results} />
-					</div>
+					{reticleLimit && (
+						<div className="panel">
+							<h2>Reticle Results</h2>
+							<ReticleCanvas
+								dieWidth={parseFloat(dieWidth)}
+								dieHeight={parseFloat(dieHeight)}
+								scribeHoriz={parseFloat(scribeHoriz)}
+								scribeVert={parseFloat(scribeVert)}
+								mmToPxScale={12}
+								showReticleBackground={showReticleBackground}
+								halfField={halfField}
+							/>
+							<Checkbox
+								label="Show Illustrative Background"
+								onChange={handleShowReticleBackgroundChange}
+								checked={showReticleBackground}
+							/>
+							<hr />
+							<ReticleStats results={easterEggEnabled ? null : results} />
+						</div>
+					)}
 					<a
 						href="https://www.semianalysis.com/"
 						target="_blank"

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,9 +1,4 @@
-import React, {
-	useState,
-	useEffect,
-	useRef,
-	useMemo,
-} from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import { Checkbox } from "./Checkbox/Checkbox";
 import { NumberInput } from "./NumberInput/NumberInput";
 import { useInputs } from "../hooks/useInputs";
@@ -168,12 +163,15 @@ function App() {
 			criticalLayers: parseFloat(criticalLayers),
 			manualYield: parseFloat(manualYield),
 		},
-		selectedModel,
-		substrateShape,
-		panelSize,
-		waferSize,
-		fieldWidthMM,
-		fieldHeightMM,
+		{
+			yieldModel: selectedModel,
+			substrateShape,
+			panelSize,
+			discSize: waferSize,
+			fieldWidth: fieldWidthMM,
+			fieldHeight: fieldHeightMM,
+			reticleLimit,
+		},
 	);
 	const easterEggEnabled = useEasterEgg();
 	const outputRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/ResultsStats/ResultsStats.test.tsx
+++ b/src/components/ResultsStats/ResultsStats.test.tsx
@@ -30,6 +30,7 @@ describe("ResultStats", () => {
 				dieHeight={10}
 				waferWidth={300}
 				waferHeight={400}
+				reticleLimit={true}
 			/>
 		);
 
@@ -51,6 +52,7 @@ describe("ResultStats", () => {
 				dieHeight={10}
 				waferWidth={200}
 				waferHeight={200}
+				reticleLimit={true}
 			/>
 		);
 
@@ -67,6 +69,7 @@ describe("ResultStats", () => {
 				dieHeight={10}
 				waferWidth={200}
 				waferHeight={200}
+				reticleLimit={true}
 			/>
 		);
 
@@ -88,6 +91,7 @@ describe("ResultStats", () => {
 				dieHeight={dieHeight}
 				waferWidth={waferWidth}
 				waferHeight={waferHeight}
+				reticleLimit={true}
 			/>
 		);
 
@@ -95,6 +99,22 @@ describe("ResultStats", () => {
 
 		expect(screen.getByText(new RegExp(`Total Waste Area: ${expected}cm²`, 'ig'))).toBeInTheDocument();
 	});
+
+	it('does not show exposure count if reticle limit is turned off', () => {
+		render(
+			<WaferStats
+				results={results}
+				shape="Panel"
+				dieWidth={10}
+				dieHeight={10}
+				waferWidth={200}
+				waferHeight={200}
+				reticleLimit={false}
+			/>
+		);
+
+		expect(screen.queryByText(/Exposures/i)).not.toBeInTheDocument();
+	})
 
 	it('renders the ReticleStats component with correct values', () => {
 		render(

--- a/src/components/ResultsStats/ResultsStats.test.tsx
+++ b/src/components/ResultsStats/ResultsStats.test.tsx
@@ -97,7 +97,7 @@ describe("ResultStats", () => {
 
 		const expected = ((waferWidth * waferHeight) - (results.goodDies * dieWidth * dieHeight)) / 100;
 
-		expect(screen.getByText(new RegExp(`Total Waste Area: ${expected}cm²`, 'ig'))).toBeInTheDocument();
+		expect(screen.getByText(new RegExp(`Total Waste Area: ${expected}cm²`, 'i'))).toBeInTheDocument();
 	});
 
 	it('does not show exposure count if reticle limit is turned off', () => {

--- a/src/components/ResultsStats/ResultsStats.tsx
+++ b/src/components/ResultsStats/ResultsStats.tsx
@@ -56,6 +56,7 @@ export function WaferStats(props: {
 	dieHeight: number;
 	waferWidth: number;
 	waferHeight: number;
+	reticleLimit: boolean;
 }) {
 	const waferArea = waferAreaCm(
 		props.shape,
@@ -102,22 +103,24 @@ export function WaferStats(props: {
 						"%",
 					)}
 				</li>
+			</ul>
+			<ul className="result-stats__list">
 				<li className="result-stats__result result-stats__result--die-cost">
 					<DollarIcon />
 					Cost Per Die: {`$${displayValue(props.results?.dieCost)}`}
 				</li>
-			</ul>
-			<ul className="result-stats__list">
-				<li className="result-stats__result result-stats__result--shot-count">
-					<ShutterIcon />
-					Exposures:{" "}
-					{displayValue(
-						(props.results?.fullShotCount || 0) +
-							(props.results?.partialShotCount || 0),
-					)}{" "}
-					({displayValue(props.results?.fullShotCount)} full,{" "}
-					{displayValue(props.results?.partialShotCount)} partial)
-				</li>
+				{props.reticleLimit && (
+					<li className="result-stats__result result-stats__result--shot-count">
+						<ShutterIcon />
+						Exposures:{" "}
+						{displayValue(
+							(props.results?.fullShotCount || 0) +
+								(props.results?.partialShotCount || 0),
+						)}{" "}
+						({displayValue(props.results?.fullShotCount)} full,{" "}
+						{displayValue(props.results?.partialShotCount)} partial)
+					</li>
+				)}
 				{props.shape === "Panel" ? (
 					<>
 						<li className="result-stats__result result-stats__result--panel-width">
@@ -162,9 +165,7 @@ export function WaferStats(props: {
 	);
 }
 
-export function ReticleStats(props: {
-	results: FabResults;
-}) {
+export function ReticleStats(props: { results: FabResults }) {
 	return (
 		<div className="result-stats" aria-busy={!props.results}>
 			<ul className="result-stats__list">
@@ -184,7 +185,7 @@ export function ReticleStats(props: {
 					Reticle Utilization:{" "}
 					{displayValue(
 						props.results?.reticleUtilization &&
-						props.results?.reticleUtilization * 100,
+							props.results?.reticleUtilization * 100,
 						"%",
 					)}
 				</li>

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { FabResults, SubstrateShape } from "../types";
-import { waferSizes, panelSizes, yieldModels, minDieEdge } from "../config";
+import { waferSizes, panelSizes, yieldModels } from "../config";
 import {
 	evaluateDiscInputs,
 	evaluatePanelInputs,
@@ -31,15 +31,32 @@ export function useInputs(
 ) {
 	const [results, setResults] = useState<FabResults>(null);
 	const [validationError, setValidationError] = useState<string>();
+	const waferWidth =
+		shape === "Panel"
+			? panelSizes[panelSize].width
+			: waferSizes[discSize].width;
+	const waferHeight =
+		shape === "Panel"
+			? panelSizes[panelSize].height
+			: waferSizes[discSize].width;
 
 	useDebouncedEffect(
 		() => {
 			// Reset to defaults if we can't use one or more values
-			const validationErrors = Object.keys(validations).map((validation) => {
-				const validationFn =
-					validations[validation as keyof typeof validations];
-				return validationFn(values, { fieldWidth, fieldHeight });
-			}).filter(Boolean);
+			const validationErrors = Object.keys(validations)
+				.map((validation) => {
+					const validationFn =
+						validations[validation as keyof typeof validations];
+					return validationFn(
+						values,
+						{ fieldWidth, fieldHeight },
+						{
+							waferWidth,
+							waferHeight,
+						},
+					);
+				})
+				.filter(Boolean);
 
 			if (validationErrors.length) {
 				setResults(null);

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -9,34 +9,40 @@ import {
 import { useDebouncedEffect } from "./useDebouncedEffect";
 import { validations } from "../utils/validations";
 
+interface Options {
+	discSize: keyof typeof waferSizes;
+	fieldHeight: number;
+	fieldWidth: number;
+	panelSize: keyof typeof panelSizes;
+	reticleLimit: boolean;
+	substrateShape: SubstrateShape;
+	yieldModel: keyof typeof yieldModels;
+}
+
 /**
  * Given the numeric inputs, selected wafer properties, and a yield model, calculate
  * the expected fabrication results.
  * @param values numeric values provided by the user via inputs
- * @param yieldModel mathematical model for calculating yield
- * @param shape wafer shape
- * @param panelSize chosen size of panel wafer
- * @param discSize chosen size of disc wafer
- * @param fieldWidth width of one shot/field
- * @param fieldHeight height of one shot/field
+ * @param options wafer properties, yield model, etc.
  */
-export function useInputs(
-	values: InputValues,
-	yieldModel: keyof typeof yieldModels,
-	shape: SubstrateShape,
-	panelSize: keyof typeof panelSizes,
-	discSize: keyof typeof waferSizes,
-	fieldWidth: number,
-	fieldHeight: number,
-) {
+export function useInputs(values: InputValues, options: Options) {
+	const {
+		substrateShape,
+		panelSize,
+		discSize,
+		yieldModel,
+		fieldWidth,
+		fieldHeight,
+		reticleLimit,
+	} = options;
 	const [results, setResults] = useState<FabResults>(null);
 	const [validationError, setValidationError] = useState<string>();
 	const waferWidth =
-		shape === "Panel"
+		substrateShape === "Panel"
 			? panelSizes[panelSize].width
 			: waferSizes[discSize].width;
 	const waferHeight =
-		shape === "Panel"
+		substrateShape === "Panel"
 			? panelSizes[panelSize].height
 			: waferSizes[discSize].width;
 
@@ -62,7 +68,7 @@ export function useInputs(
 				setResults(null);
 				setValidationError(validationErrors[0]);
 			} else {
-				if (shape === "Wafer") {
+				if (substrateShape === "Wafer") {
 					setResults(
 						evaluateDiscInputs(
 							values,
@@ -70,9 +76,11 @@ export function useInputs(
 							yieldModel,
 							fieldWidth,
 							fieldHeight,
+							// Center die on the wafer if Reticle Limit is turned off
+							reticleLimit,
 						),
 					);
-				} else if (shape === "Panel") {
+				} else if (substrateShape === "Panel") {
 					setResults(
 						evaluatePanelInputs(
 							values,
@@ -80,6 +88,8 @@ export function useInputs(
 							yieldModel,
 							fieldWidth,
 							fieldHeight,
+							// Center die on the panel if Reticle Limit is turned off
+							reticleLimit,
 						),
 					);
 				}
@@ -87,7 +97,7 @@ export function useInputs(
 		},
 		[
 			JSON.stringify(values),
-			shape,
+			substrateShape,
 			panelSize,
 			discSize,
 			yieldModel,

--- a/src/types/dies.ts
+++ b/src/types/dies.ts
@@ -25,5 +25,5 @@ export type FabResults = null | {
 	fullShotCount: number,
 	partialShotCount: number,
 	reticleUtilization: number,
-	dieCost: number;
+	dieCost?: number;
 };

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -292,7 +292,7 @@ describe("Calculations", () => {
 				criticalLayers: 50,
 				manualYield: 100,
 			};
-			const result = evaluateDiscInputs(inputVals, "s300mm", "murphy", 26, 33);
+			const result = evaluateDiscInputs(inputVals, "s300mm", "murphy", 26, 33, false);
 			expect(result?.reticleUtilization).toBeCloseTo(0.895105, 6);
 		});
 	});

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -398,8 +398,7 @@ export function evaluatePanelInputs(
 		dieMap.dies.map((die) => die.dieState)
 	);
 
-	const dieCost = goodDies > 0 ? substrateCost / goodDies : 0;
-
+	const dieCost = goodDies > 0 ? substrateCost / goodDies : undefined;
 
 	return {
 		dies: dieMap.dies,
@@ -519,7 +518,7 @@ export function evaluateDiscInputs(
 		dieMap.dies.map((die) => die.dieState)
 	);
 
-	const dieCost = goodDies > 0 ? substrateCost / goodDies : 0;
+	const dieCost = goodDies > 0 ? substrateCost / goodDies : undefined;
 
 	return {
 		dies: dieMap.dies,

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -117,16 +117,23 @@ export type InputValues = {
 /**
  * Get the offset (x, y) to apply to all dies.
  * @param inputs
- * @param waferCenteringEnabled center by wafer or by die
+ * @param fieldWidth
+ * @param fieldHeight
+ * @param fieldCenteringEnabled center by shot or by shot grid
  * @returns object containing x and y offsets
  */
-function getDieOffset(inputs: InputValues, waferCenteringEnabled: boolean) {
-	const dieOffsetX = waferCenteringEnabled
+function getDieOffset(
+	inputs: InputValues,
+	fieldWidth: number,
+	fieldHeight: number,
+	fieldCenteringEnabled: boolean
+) {
+	const dieOffsetX = fieldCenteringEnabled
 		? inputs.scribeHoriz * 0.5
-		: inputs.dieWidth * -0.5;
-	const dieOffsetY = waferCenteringEnabled
+		: fieldWidth * -0.5;
+	const dieOffsetY = fieldCenteringEnabled
 		? inputs.scribeVert * 0.5
-		: inputs.dieHeight * -0.5;
+		: fieldHeight * -0.5;
 	return {
 		x: dieOffsetX + inputs.transHoriz,
 		y: dieOffsetY + inputs.transVert
@@ -258,7 +265,7 @@ export function createDieMap(
 	});
 
 	// Randomly distribute n defective dies amongst good dies on the map based on fab yield
-	const numDefectiveDies = goodDies - Math.floor(fabYield * goodDies);
+	const numDefectiveDies = Math.round((1 - fabYield) * goodDies);
 	const defectiveDieKeys = randomNumberSetFromRange(
 		0,
 		goodDies - 1,
@@ -306,6 +313,7 @@ function getReticleUtilization(
  * @param selectedModel selected yield model
  * @param fieldWidth reticle width
  * @param fieldHeight reticle height
+ * @param fieldCenteringEnabled whether to center-align the shot(s) on the wafer vs the shot grid
  * @returns object containing all dies, full and partial shot counts, and positions
  */
 export function evaluatePanelInputs(
@@ -314,6 +322,7 @@ export function evaluatePanelInputs(
 	selectedModel: keyof typeof yieldModels,
 	fieldWidth: number,
 	fieldHeight: number,
+	fieldCenteringEnabled: boolean,
 ): FabResults {
 	const {
 		dieWidth,
@@ -327,7 +336,6 @@ export function evaluatePanelInputs(
 		manualYield,
 		substrateCost,
 	} = inputVals;
-	let dies = [];
 	const fabYield = getFabYield(
 		defectRate,
 		criticalArea,
@@ -339,7 +347,9 @@ export function evaluatePanelInputs(
 
 	const { x: offsetX, y: offsetY } = getDieOffset(
 		inputVals,
-		true
+		fieldWidth,
+		fieldHeight,
+		fieldCenteringEnabled
 	);
 
 	// First, calculate the reticle shot map
@@ -423,6 +433,7 @@ export function evaluatePanelInputs(
  * @param selectedModel selected yield model
  * @param fieldWidth reticle width
  * @param fieldHeight reticle height
+ * @param fieldCenteringEnabled whether to center-align the shot(s) on the wafer vs the shot grid
  * @returns object containing all dies, full and partial shot counts, and positions
  */
 export function evaluateDiscInputs(
@@ -431,6 +442,7 @@ export function evaluateDiscInputs(
 	selectedModel: keyof typeof yieldModels,
 	fieldWidth: number,
 	fieldHeight: number,
+	fieldCenteringEnabled: boolean,
 ): FabResults {
 	const {
 		dieWidth,
@@ -456,7 +468,9 @@ export function evaluateDiscInputs(
 
 	const { x: offsetX, y: offsetY } = getDieOffset(
 		inputVals,
-		true
+		fieldWidth,
+		fieldHeight,
+		fieldCenteringEnabled
 	);
 
 	// First, calculate the reticle shot map

--- a/src/utils/geometry.test.ts
+++ b/src/utils/geometry.test.ts
@@ -1,4 +1,5 @@
 import {
+	getRectCenter,
 	getRectCorners,
 	isInsideCircle,
 	isInsideRectangle,
@@ -7,6 +8,40 @@ import {
 } from "./geometry";
 
 describe("geometry utils", () => {
+	describe("getRectCenter", () => {
+		it("should calculate the center of a rectangle with positive width and height", () => {
+			const x = 0;
+			const y = 0;
+			const width = 10;
+			const height = 5;
+
+			const result = getRectCenter(x, y, width, height);
+
+			expect(result).toEqual({ x: 5, y: 2.5 });
+		});
+
+		it("should handle rectangles with negative coordinates", () => {
+			const x = -5;
+			const y = -5;
+			const width = 10;
+			const height = 5;
+
+			const result = getRectCenter(x, y, width, height);
+
+			expect(result).toEqual({ x: 0, y: -2.5 });
+		});
+
+		it("should handle rectangles with zero width and height", () => {
+			const x = 10;
+			const y = 20;
+			const width = 0;
+			const height = 0;
+
+			const result = getRectCenter(x, y, width, height);
+
+			expect(result).toEqual({ x: 10, y: 20 });
+		});
+	})
 	describe("getRectCorners", () => {
 		it("should calculate the corners of a rectangle with positive width and height", () => {
 			const x = 0;

--- a/src/utils/validations.test.ts
+++ b/src/utils/validations.test.ts
@@ -5,6 +5,7 @@ import { minDieEdge } from "../config";
 
 describe("validations", () => {
 	const fieldSize = { fieldWidth: 26, fieldHeight: 33 };
+	const waferSize = { waferWidth: 300, waferHeight: 300 };
 
 	describe("dieWidthAndHorizontalScribe (validations.dieWidth / validations.scribeHoriz)", () => {
 		it("returns 'Invalid die width' if dieWidth is NaN", () => {
@@ -12,7 +13,7 @@ describe("validations", () => {
 				dieWidth: NaN,
 				scribeHoriz: 10,
 			} as any; // Casting so we don't need every property
-			const result = validations.dieWidth(inputs, fieldSize);
+			const result = validations.dieWidth(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid die width");
 		});
 
@@ -21,7 +22,7 @@ describe("validations", () => {
 				dieWidth: 10,
 				scribeHoriz: NaN,
 			} as any;
-			const result = validations.dieWidth(inputs, fieldSize);
+			const result = validations.dieWidth(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid horizontal scribe line width");
 		});
 
@@ -30,7 +31,7 @@ describe("validations", () => {
 				dieWidth: minDieEdge - 0.01,
 				scribeHoriz: 1,
 			} as any;
-			const result = validations.dieWidth(inputs, fieldSize);
+			const result = validations.dieWidth(inputs, fieldSize, waferSize);
 			expect(result).toBe(`Die must be at least ${minDieEdge}mm wide`);
 		});
 
@@ -39,8 +40,8 @@ describe("validations", () => {
 				dieWidth: 26,
 				scribeHoriz: 0.1,
 			} as any;
-			const result = validations.dieWidth(inputs, fieldSize);
-			expect(result).toBe(
+			const result = validations.dieWidth(inputs, fieldSize, waferSize);
+			expect(result).toContain(
 				`Die and scribe line width must be less than or equal to the field width (${fieldSize.fieldWidth}mm).`,
 			);
 		});
@@ -50,7 +51,7 @@ describe("validations", () => {
 				dieWidth: minDieEdge,
 				scribeHoriz: 1,
 			} as any;
-			const result = validations.dieWidth(inputs, fieldSize);
+			const result = validations.dieWidth(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 
@@ -59,7 +60,7 @@ describe("validations", () => {
 				dieWidth: NaN,
 				scribeHoriz: 1,
 			} as any;
-			const result = validations.scribeHoriz(inputs, fieldSize);
+			const result = validations.scribeHoriz(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid die width");
 		});
 	});
@@ -70,7 +71,7 @@ describe("validations", () => {
 				dieHeight: NaN,
 				scribeVert: 1,
 			} as any;
-			const result = validations.dieHeight(inputs, fieldSize);
+			const result = validations.dieHeight(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid die height");
 		});
 
@@ -79,7 +80,7 @@ describe("validations", () => {
 				dieHeight: 10,
 				scribeVert: NaN,
 			} as any;
-			const result = validations.dieHeight(inputs, fieldSize);
+			const result = validations.dieHeight(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid vertical scribe line width");
 		});
 
@@ -88,7 +89,7 @@ describe("validations", () => {
 				dieHeight: minDieEdge - 0.01,
 				scribeVert: 1,
 			} as any;
-			const result = validations.dieHeight(inputs, fieldSize);
+			const result = validations.dieHeight(inputs, fieldSize, waferSize);
 			expect(result).toBe(`Die must be at least ${minDieEdge}mm tall`);
 		});
 
@@ -97,8 +98,8 @@ describe("validations", () => {
 				dieHeight: 33,
 				scribeVert: 0.1,
 			} as any;
-			const result = validations.dieHeight(inputs, fieldSize);
-			expect(result).toBe(
+			const result = validations.dieHeight(inputs, fieldSize, waferSize);
+			expect(result).toContain(
 				`Die and scribe line height must be less than or equal to the field height (${fieldSize.fieldHeight}mm).`,
 			);
 		});
@@ -108,7 +109,7 @@ describe("validations", () => {
 				dieHeight: minDieEdge,
 				scribeVert: 1,
 			} as any;
-			const result = validations.dieHeight(inputs, fieldSize);
+			const result = validations.dieHeight(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 
@@ -117,7 +118,7 @@ describe("validations", () => {
 				dieHeight: NaN,
 				scribeVert: 1,
 			} as any;
-			const result = validations.scribeVert(inputs, fieldSize);
+			const result = validations.scribeVert(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid die height");
 		});
 	});
@@ -129,7 +130,7 @@ describe("validations", () => {
 				dieWidth: 10,
 				dieHeight: 10,
 			} as any;
-			const result = validations.criticalArea(inputs, fieldSize);
+			const result = validations.criticalArea(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid critical area");
 		});
 
@@ -139,7 +140,7 @@ describe("validations", () => {
 				dieWidth: 10,
 				dieHeight: 10,
 			} as any;
-			const result = validations.criticalArea(inputs, fieldSize);
+			const result = validations.criticalArea(inputs, fieldSize, waferSize);
 			expect(result).toBe(
 				"Critical area must be less than or equal to die area",
 			);
@@ -151,7 +152,7 @@ describe("validations", () => {
 				dieWidth: 10,
 				dieHeight: 10,
 			} as any;
-			const result = validations.criticalArea(inputs, fieldSize);
+			const result = validations.criticalArea(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -161,7 +162,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				defectRate: -1,
 			} as any;
-			const result = validations.defectRate(inputs, fieldSize);
+			const result = validations.defectRate(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid defect rate");
 		});
 
@@ -169,7 +170,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				defectRate: 10,
 			} as any;
-			const result = validations.defectRate(inputs, fieldSize);
+			const result = validations.defectRate(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -179,7 +180,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				lossyEdgeWidth: -5,
 			} as any;
-			const result = validations.lossyEdgeWidth(inputs, fieldSize);
+			const result = validations.lossyEdgeWidth(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid lossy edge width");
 		});
 
@@ -187,7 +188,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				lossyEdgeWidth: 0,
 			} as any;
-			const result = validations.lossyEdgeWidth(inputs, fieldSize);
+			const result = validations.lossyEdgeWidth(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -197,7 +198,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				notchKeepOutHeight: -2,
 			} as any;
-			const result = validations.notchKeepOutHeight(inputs, fieldSize);
+			const result = validations.notchKeepOutHeight(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid notch keep-out height");
 		});
 
@@ -205,7 +206,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				notchKeepOutHeight: 10,
 			} as any;
-			const result = validations.notchKeepOutHeight(inputs, fieldSize);
+			const result = validations.notchKeepOutHeight(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -215,7 +216,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				transHoriz: NaN,
 			} as any;
-			const result = validations.transHoriz(inputs, fieldSize);
+			const result = validations.transHoriz(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid horizontal translation");
 		});
 
@@ -223,7 +224,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				transHoriz: 5,
 			} as any;
-			const result = validations.transHoriz(inputs, fieldSize);
+			const result = validations.transHoriz(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -233,7 +234,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				transVert: NaN,
 			} as any;
-			const result = validations.transVert(inputs, fieldSize);
+			const result = validations.transVert(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid vertical translation");
 		});
 
@@ -241,7 +242,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				transVert: 5,
 			} as any;
-			const result = validations.transVert(inputs, fieldSize);
+			const result = validations.transVert(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	});
@@ -251,7 +252,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				criticalLayers: 0.5,
 			} as any;
-			const result = validations.criticalLayers(inputs, fieldSize);
+			const result = validations.criticalLayers(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid critical layer count");
 		});
 
@@ -259,7 +260,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				criticalLayers: 50,
 			} as any;
-			const result = validations.criticalLayers(inputs, fieldSize);
+			const result = validations.criticalLayers(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 
@@ -267,7 +268,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				criticalLayers: 100.5,
 			} as any;
-			const result = validations.criticalLayers(inputs, fieldSize);
+			const result = validations.criticalLayers(inputs, fieldSize, waferSize);
 			expect(result).toBe("Invalid critical layer count");
 		});
 	});
@@ -277,7 +278,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				manualYield: 101,
 			} as any;
-			const result = validations.manualYield(inputs, fieldSize);
+			const result = validations.manualYield(inputs, fieldSize, waferSize);
 			expect(result).toBe("Manual yield % must be a number from 0-100");
 		});
 
@@ -285,7 +286,7 @@ describe("validations", () => {
 			const inputs: InputValues = {
 				manualYield: 50,
 			} as any;
-			const result = validations.manualYield(inputs, fieldSize);
+			const result = validations.manualYield(inputs, fieldSize, waferSize);
 			expect(result).toBeUndefined();
 		});
 	})

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -35,7 +35,7 @@ const dieWidthAndHorizontalScribe: Validator = (
 	}
 
 	if (dieWidth + scribeHoriz > fieldWidth) {
-		return `Die and scribe line width must be less than or equal to the field width (${fieldWidth}mm).`;
+		return `Die and scribe line width must be less than or equal to the field width (${fieldWidth}mm). Reduce the total width or disable Reticle Limit.`;
 	}
 };
 
@@ -62,7 +62,7 @@ const dieHeightAndVerticalScribe: Validator = (
 	}
 
 	if (dieHeight + scribeVert > fieldHeight) {
-		return `Die and scribe line height must be less than or equal to the field height (${fieldHeight}mm).`;
+		return `Die and scribe line height must be less than or equal to the field height (${fieldHeight}mm). Reduce the total height or disable Reticle Limit.`;
 	}
 };
 

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -9,7 +9,7 @@ type Validator = (
 	fieldSize: {
 		fieldWidth: number;
 		fieldHeight: number;
-	},
+	}
 ) => string | undefined;
 
 /**

--- a/src/utils/validations.ts
+++ b/src/utils/validations.ts
@@ -9,6 +9,10 @@ type Validator = (
 	fieldSize: {
 		fieldWidth: number;
 		fieldHeight: number;
+	},
+	waferSize: {
+		waferWidth: number;
+		waferHeight: number;
 	}
 ) => string | undefined;
 
@@ -17,10 +21,12 @@ type Validator = (
  * @param dieWidth
  * @param scribeHoriz
  * @param fieldWidth
+ * @param waferWidth
  */
 const dieWidthAndHorizontalScribe: Validator = (
 	{ dieWidth, scribeHoriz },
 	{ fieldWidth },
+	{ waferWidth },
 ) => {
 	if (!validPositiveNumber(dieWidth)) {
 		return "Invalid die width";
@@ -34,6 +40,10 @@ const dieWidthAndHorizontalScribe: Validator = (
 		return `Die must be at least ${minDieEdge}mm wide`;
 	}
 
+	if (dieWidth + scribeHoriz > waferWidth) {
+		return `Die and scribe line width must be less than or equal to the wafer width (${waferWidth}mm).`;
+	}
+
 	if (dieWidth + scribeHoriz > fieldWidth) {
 		return `Die and scribe line width must be less than or equal to the field width (${fieldWidth}mm). Reduce the total width or disable Reticle Limit.`;
 	}
@@ -44,10 +54,12 @@ const dieWidthAndHorizontalScribe: Validator = (
  * @param dieHeight
  * @param scribeVert
  * @param fieldHeight
+ * @param waferHeight
  */
 const dieHeightAndVerticalScribe: Validator = (
 	{ dieHeight, scribeVert },
 	{ fieldHeight },
+	{ waferHeight },
 ) => {
 	if (!validPositiveNumber(dieHeight)) {
 		return "Invalid die height";
@@ -59,6 +71,10 @@ const dieHeightAndVerticalScribe: Validator = (
 
 	if (dieHeight < minDieEdge) {
 		return `Die must be at least ${minDieEdge}mm tall`;
+	}
+
+	if (dieHeight + scribeVert > waferHeight) {
+		return `Die and scribe line height must be less than or equal to the wafer height (${waferHeight}mm).`;
 	}
 
 	if (dieHeight + scribeVert > fieldHeight) {


### PR DESCRIPTION
Updates the behavior of the calculator when the Reticle Limit checkbox is unchecked so that:

- Shot mapping is bypassed, mimicking the behavior of the v1 calculator
  - In actuality we are taking one big shot whose dimensions match and completely cover the wafer
- Die of any dimensions may be specified and will be displayed centered on the wafer
  - Die dimensions are constrained only by the wafer size. Die dimensions exceeding the wafer dimensions will result in a new validation error message
- All reticle-related output is hidden
- Half Field Exposures and Show Reticle Shot Grid checkboxes are automatically unchecked and disabled as this functionality doesn't make sense in this context

🎥 [Loom demo and description here](https://www.loom.com/share/2e1168e1b64643cd922dee0882c777f5)

![Screenshot 2025-05-06 at 15 21 36](https://github.com/user-attachments/assets/6339b60e-5c6d-4637-9f2a-1a91add76b6b)

![Screenshot 2025-05-06 at 15 24 47](https://github.com/user-attachments/assets/f5112148-d455-40f4-be94-615b7727c649)
