### PR TITLE
Trim shot waste area

### DIFF
--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.2.3
+ * Version:           0.3.0
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.2.2
+ * Version:           0.2.3
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.2.3",
+			"version": "0.3.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.2.1",
+	"version": "0.2.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.2.1",
+			"version": "0.2.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/src/assets/scss/components/_reticle-canvas.scss
+++ b/src/assets/scss/components/_reticle-canvas.scss
@@ -29,9 +29,9 @@
 	.reticle-canvas__inner {
 		@include mixins.rainbow-background;
 
-		width: calc(104 / 152.4 * 100%);
-		height: calc(132 / 152.4 * 100%);
-		outline: 1px solid blue;
+		border: 1px solid blue;
+		max-width: 100%;
+		max-height: 100%;
 		opacity: 0.75;
 		background-position: 100%;
 		background-size: 300%;

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { act } from "react";
 import App from "./App";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import { userEvent } from "@testing-library/user-event";
@@ -6,22 +6,30 @@ import { defaultFieldWidth, defaultFieldHeight } from "../config";
 
 describe("App", () => {
 	it("calculates the correct number of total 5mm dies on a 300mm panel with no scribe lines", async () => {
+		let excludedCountNum = 0;
+		let totalCountNum = 0;
+
 		render(<App />);
 		const user = userEvent.setup();
-		await user.click(screen.getByRole("radio", {
-			name: /Panel/
-		}));
+
+		await user.click(
+			screen.getByRole("radio", {
+				name: /Panel/,
+			}),
+		);
 
 		const widthInput = screen.getByRole("spinbutton", {
-			name: /Width/
+			name: /Width/,
 		});
 		const scribeLinesXInput = screen.getByRole("spinbutton", {
-			name: /Scribe Line Minimum X/
+			name: /Scribe Line Minimum X/,
 		});
 		const scribeLinesYInput = screen.getByRole("spinbutton", {
-			name: /Scribe Line Minimum Y/
+			name: /Scribe Line Minimum Y/,
 		});
-		const maintainAspectRatioCheckbox = screen.getByRole("checkbox", { name: /Aspect Ratio/ });
+		const maintainAspectRatioCheckbox = screen.getByRole("checkbox", {
+			name: /Aspect Ratio/,
+		});
 
 		await user.click(maintainAspectRatioCheckbox);
 		await user.clear(widthInput);
@@ -31,30 +39,53 @@ describe("App", () => {
 		await user.clear(scribeLinesYInput);
 		await user.type(scribeLinesYInput, "0");
 
-		// How many 26mm x 33mm field shots can we fit in the panel?
-		const fieldCountX = Math.ceil(300 / 26);
-		const fieldCountY = Math.ceil(300 / 33);
-		const fieldCount = fieldCountX * fieldCountY;
-		// How many 5mm square dies can we fit in a single field shot?
-		const dieCountX = Math.floor(26 / 5);
-		const dieCountY = Math.floor(33 / 5);
-		const dieCount = dieCountX * dieCountY;
-		// How many dies can we fit in the entire panel?
-		const totalDieCount = fieldCount * dieCount;
+		await waitFor(async () => {
+			const totalTextNode = await screen.findByText(/Total Dies/);
 
-		expect(await screen.findByText(new RegExp(totalDieCount.toString()))).toBeInTheDocument();
+			if (totalTextNode.textContent) {
+				// Wait for the calculation to appear
+				const countStr = await within(totalTextNode).findByText(/\d+/);
+
+				if (countStr.textContent) {
+					const countMatch = countStr.textContent.match(/\d+/)?.[0];
+					totalCountNum = countMatch ? parseInt(countMatch) : 0;
+				}
+			}
+
+			const excludedTextNode = await screen.findByText(/Excluded Dies/);
+
+			if (excludedTextNode.textContent) {
+				// Wait for the calculation to appear
+				const countStr = await within(excludedTextNode).findByText(/\d+/);
+
+				if (countStr.textContent) {
+					const countMatch = countStr.textContent.match(/\d+/)?.[0];
+					excludedCountNum = countMatch ? parseInt(countMatch) : 0;
+				}
+			}
+
+			// How many die can we fit in the entire panel?
+			const expectedTotalDieCount = 300 * 300 / (5 * 5);
+
+			expect(totalCountNum - excludedCountNum).toEqual(expectedTotalDieCount);
+		}, { timeout: 200 });
 	});
 
 	it("calculates yields for wafer shape", async () => {
 		render(<App />);
 		const user = userEvent.setup();
-		await user.click(screen.getByRole("radio", {
-			name: /Wafer/
-		}));
+		await user.click(
+			screen.getByRole("radio", {
+				name: /Wafer/,
+			}),
+		);
 		// No notch keepout
-		await user.type(screen.getByRole("spinbutton", {
-			name: /Notch keep-out/
-		}), "{backspace}0");
+		await user.type(
+			screen.getByRole("spinbutton", {
+				name: /Notch keep-out/,
+			}),
+			"{backspace}0",
+		);
 		await waitFor(() => expect(screen.getByText(/1104/)).toBeInTheDocument());
 	});
 
@@ -64,32 +95,30 @@ describe("App", () => {
 		// Get the number of dies displayed for each state and the total number of dies.
 		let totalDiesCount = 0;
 		let allStatesCount = 0;
-		await Promise.all([
-			"Total",
-			"Good",
-			"Defective",
-			"Partial",
-			"Excluded"
-		].map(async (label) => {
-			const regex = new RegExp(`${label} Dies`);
-			const textNode = await screen.findByText(regex);
+		await Promise.all(
+			["Total", "Good", "Defective", "Partial", "Excluded"].map(
+				async (label) => {
+					const regex = new RegExp(`${label} Dies`);
+					const textNode = await screen.findByText(regex);
 
-			if (textNode.textContent) {
-				// Wait for the calculation to appear
-				const countStr = await within(textNode).findByText(/\d+/);
+					if (textNode.textContent) {
+						// Wait for the calculation to appear
+						const countStr = await within(textNode).findByText(/\d+/);
 
-				if (countStr.textContent) {
-					const countMatch = countStr.textContent.match(/\d+/)?.[0];
-					const countNum = countMatch ? parseInt(countMatch) : 0;
+						if (countStr.textContent) {
+							const countMatch = countStr.textContent.match(/\d+/)?.[0];
+							const countNum = countMatch ? parseInt(countMatch) : 0;
 
-					if (label === "Total") {
-						totalDiesCount = countNum;
-					} else {
-						allStatesCount += countNum;
+							if (label === "Total") {
+								totalDiesCount = countNum;
+							} else {
+								allStatesCount += countNum;
+							}
+						}
 					}
-				}
-			}
-		}));
+				},
+			),
+		);
 
 		expect(totalDiesCount).toBeGreaterThan(0);
 		expect(totalDiesCount).toEqual(allStatesCount);
@@ -98,7 +127,9 @@ describe("App", () => {
 	it("automatically adjusts the other die dimension input when one is changed with maintain aspect ratio on", async () => {
 		render(<App />);
 		const user = userEvent.setup();
-		const maintainAspectRatioCheckbox = screen.getByRole("checkbox", { name: /Aspect Ratio/ });
+		const maintainAspectRatioCheckbox = screen.getByRole("checkbox", {
+			name: /Aspect Ratio/,
+		});
 		const dieWidthInput = screen.getByRole("spinbutton", { name: /Width/ });
 		const dieHeightInput = screen.getByRole("spinbutton", { name: /Height/ });
 
@@ -141,15 +172,23 @@ describe("App", () => {
 	it("shows how many full and partial shots will be taken and how many die fit on a reticle", async () => {
 		render(<App />);
 		const totalDiesNode = await screen.findByText(/Total Dies: [0-9]+/);
-		const totalDies = parseInt(totalDiesNode.textContent?.match(/\d+/)?.[0] || "0");
+		const totalDies = parseInt(
+			totalDiesNode.textContent?.match(/\d+/)?.[0] || "0",
+		);
 
 		// Get the number of dies per shot
-		const diePerReticleNode = await screen.findByText(/Die Per Reticle: [0-9]+/);
-		const diePerReticle = parseInt(diePerReticleNode.textContent?.match(/\d+/)?.[0] || "0");
+		const diePerReticleNode = await screen.findByText(
+			/Die Per Reticle: [0-9]+/,
+		);
+		const diePerReticle = parseInt(
+			diePerReticleNode.textContent?.match(/\d+/)?.[0] || "0",
+		);
 
 		// Get the number of shots
 		const shotCountNode = await screen.findByText(/Exposures: [0-9]+/);
-		const shotCount = parseInt(shotCountNode.textContent?.match(/\d+/)?.[0] || "0");
+		const shotCount = parseInt(
+			shotCountNode.textContent?.match(/\d+/)?.[0] || "0",
+		);
 
 		// The total number of dies should be the number of dies per shot times the number of shots
 		expect(totalDies).toEqual(diePerReticle * shotCount);
@@ -163,7 +202,9 @@ describe("App", () => {
 		const dieWidthInput = screen.getByRole("spinbutton", { name: /Width/ });
 		const dieHeightInput = screen.getByRole("spinbutton", { name: /Height/ });
 		const reticleLimitCheckbox = screen.getByRole("checkbox", {
-			name: new RegExp(`Reticle Limit \\(${defaultFieldWidth}mm x ${defaultFieldHeight}mm\\)`)
+			name: new RegExp(
+				`Reticle Limit \\(${defaultFieldWidth}mm x ${defaultFieldHeight}mm\\)`,
+			),
 		});
 
 		// By default, Reticle Limit should be checked
@@ -179,7 +220,9 @@ describe("App", () => {
 		// Wait for validation error to appear
 		await waitFor(() => {
 			const errorText = screen.getByText(
-				new RegExp(`Die and scribe line width must be less than or equal to the field width \\(${defaultFieldWidth}mm\\)`)
+				new RegExp(
+					`Die and scribe line width must be less than or equal to the field width \\(${defaultFieldWidth}mm\\)`,
+				),
 			);
 			expect(errorText).toBeInTheDocument();
 		});
@@ -193,7 +236,9 @@ describe("App", () => {
 		await user.type(dieWidthInput, (defaultFieldWidth + 10).toString());
 
 		// Input should accept the larger value
-		expect(dieWidthInput).toHaveDisplayValue((defaultFieldWidth + 10).toString());
+		expect(dieWidthInput).toHaveDisplayValue(
+			(defaultFieldWidth + 10).toString(),
+		);
 
 		// Wait for the validation error to disappear
 		await waitFor(() => {
@@ -207,7 +252,9 @@ describe("App", () => {
 		await user.type(dieHeightInput, (defaultFieldHeight + 10).toString());
 
 		// Input should accept the larger value
-		expect(dieHeightInput).toHaveDisplayValue((defaultFieldHeight + 10).toString());
+		expect(dieHeightInput).toHaveDisplayValue(
+			(defaultFieldHeight + 10).toString(),
+		);
 
 		// Check the Reticle Limit checkbox again
 		await user.click(reticleLimitCheckbox);
@@ -220,7 +267,9 @@ describe("App", () => {
 		// And validation error should reappear
 		await waitFor(() => {
 			// We should see at least one validation error about field dimensions
-			const errorText = screen.getByText(/must be less than or equal to the field (width|height)/i);
+			const errorText = screen.getByText(
+				/must be less than or equal to the field (width|height)/i,
+			);
 			expect(errorText).toBeInTheDocument();
 		});
 	});
@@ -236,34 +285,63 @@ describe("App", () => {
 			"Manual",
 		];
 
-		it.each(yieldModelOptions)("shows the correct inputs for %s", async (model) => {
-			render(<App />);
-			const user = userEvent.setup();
-			const yieldModelSelect = await screen.findByRole("combobox", { name: "Yield Calculation Model" });
-			await user.selectOptions(yieldModelSelect, model);
-			switch (model) {
-				case "Poisson Model":
-				case "Murphy's Model":
-				case "Rectangular Model":
-				case "Moore's Model":
-				case "Seeds Model":
-					expect(screen.queryByRole("spinbutton", { name: /Defect Rate/ })).toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Die Area/ })).toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Manual Yield/ })).not.toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Layers/ })).not.toBeInTheDocument();
-					break;
-				case "Bose-Einstein Model":
-					expect(screen.queryByRole("spinbutton", { name: /Defect Rate/ })).toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Die Area/ })).toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Manual Yield/ })).not.toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Layers/ })).toBeInTheDocument();
-					break;
-				case "Manual":
-					expect(screen.queryByRole("spinbutton", { name: /Yield/ })).toBeInTheDocument()
-					expect(screen.queryByRole("spinbutton", { name: /Defect Rate/ })).not.toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Die Area/ })).not.toBeInTheDocument();
-					expect(screen.queryByRole("spinbutton", { name: /Critical Layers/ })).not.toBeInTheDocument();
-			}
-		});
-	})
+		it.each(yieldModelOptions)(
+			"shows the correct inputs for %s",
+			async (model) => {
+				render(<App />);
+				const user = userEvent.setup();
+				const yieldModelSelect = await screen.findByRole("combobox", {
+					name: "Yield Calculation Model",
+				});
+				await user.selectOptions(yieldModelSelect, model);
+				switch (model) {
+					case "Poisson Model":
+					case "Murphy's Model":
+					case "Rectangular Model":
+					case "Moore's Model":
+					case "Seeds Model":
+						expect(
+							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+						).toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),
+						).toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Manual Yield/ }),
+						).not.toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Layers/ }),
+						).not.toBeInTheDocument();
+						break;
+					case "Bose-Einstein Model":
+						expect(
+							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+						).toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),
+						).toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Manual Yield/ }),
+						).not.toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Layers/ }),
+						).toBeInTheDocument();
+						break;
+					case "Manual":
+						expect(
+							screen.queryByRole("spinbutton", { name: /Yield/ }),
+						).toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+						).not.toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),
+						).not.toBeInTheDocument();
+						expect(
+							screen.queryByRole("spinbutton", { name: /Critical Layers/ }),
+						).not.toBeInTheDocument();
+				}
+			},
+		);
+	});
 });

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -22,10 +22,10 @@ describe("App", () => {
 			name: /Width/,
 		});
 		const scribeLinesXInput = screen.getByRole("spinbutton", {
-			name: /Scribe Line Minimum X/,
+			name: /Scribe Line X/,
 		});
 		const scribeLinesYInput = screen.getByRole("spinbutton", {
-			name: /Scribe Line Minimum Y/,
+			name: /Scribe Line Y/,
 		});
 		const maintainAspectRatioCheckbox = screen.getByRole("checkbox", {
 			name: /Aspect Ratio/,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -495,8 +495,6 @@ function App() {
 							waferHeight={waferHeight}
 							easterEggEnabled={easterEggEnabled}
 							showShotMap={showShotMap}
-							fieldWidth={fieldWidthMM}
-							fieldHeight={fieldHeightMM}
 							validationError={validationError}
 						/>
 						<Checkbox

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -340,12 +340,12 @@ function App() {
 					</div>
 					<div className="input-row--two-col">
 						<NumberInput
-							label="Scribe Line Minimum X (mm)"
+							label="Scribe Line X (mm)"
 							value={scribeHoriz}
 							onChange={(event) => setScribeHoriz(event.target.value)}
 						/>
 						<NumberInput
-							label="Scribe Line Minimum Y (mm)"
+							label="Scribe Line Y (mm)"
 							value={scribeVert}
 							onChange={(event) => setScribeVert(event.target.value)}
 						/>

--- a/src/components/ResultsStats/ResultsStats.test.tsx
+++ b/src/components/ResultsStats/ResultsStats.test.tsx
@@ -18,6 +18,8 @@ const results: FabResults = {
 	partialShotCount: 5,
 	reticleUtilization: 0.75,
 	dieCost: 5.25,
+	trimmedFieldHeight: 180,
+	trimmedFieldWidth: 180,
 };
 
 describe("ResultStats", () => {

--- a/src/components/ReticleCanvas/ReticleCanvas.tsx
+++ b/src/components/ReticleCanvas/ReticleCanvas.tsx
@@ -57,7 +57,7 @@ export function ReticleCanvas(props: Props) {
 			scribeVert,
 			defaultFieldWidth,
 			defaultFieldHeight,
-			false,
+			true,
 		);
 
 		// Update canvas dimensions

--- a/src/components/ReticleCanvas/ReticleCanvas.tsx
+++ b/src/components/ReticleCanvas/ReticleCanvas.tsx
@@ -50,26 +50,15 @@ export function ReticleCanvas(props: Props) {
 			: props.scribeVert;
 
 		// Calculate the position of dies in a single shot
-		const diesInShot = getRelativeDiePositions(
+		const { diesInShot, trimmedFieldHeight, trimmedFieldWidth } = getRelativeDiePositions(
 			dieWidth,
 			dieHeight,
 			scribeHoriz,
 			scribeVert,
 			defaultFieldWidth,
 			defaultFieldHeight,
+			false,
 		);
-
-		// Trim the reticle to get the true shot size
-		const { width: trimmedFieldWidth, height: trimmedFieldHeight } =
-			getTrimmedFieldDimensions({
-				diesInShotPositions: diesInShot.positions,
-				dieWidth,
-				dieHeight,
-				scribeHoriz,
-				scribeVert,
-				fieldWidth: defaultFieldWidth,
-				fieldHeight: defaultFieldHeight,
-			});
 
 		// Update canvas dimensions
 		canvasEl.current.width = trimmedFieldWidth * props.mmToPxScale;

--- a/src/components/ReticleCanvas/ReticleCanvas.tsx
+++ b/src/components/ReticleCanvas/ReticleCanvas.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useRef, useState } from "react";
 import Tilt from "react-parallax-tilt";
-import { getRelativeDiePositions } from "../../utils/calculations";
+import {
+	getRelativeDiePositions,
+	getTrimmedFieldDimensions,
+} from "../../utils/calculations";
 import { defaultFieldWidth, defaultFieldHeight } from "../../config";
 import { OnMoveParams } from "react-parallax-tilt/dist/modern";
 
@@ -16,14 +19,9 @@ type Props = {
 
 export function ReticleCanvas(props: Props) {
 	const canvasEl = useRef<HTMLCanvasElement>(null);
-	const [tiltX, setTiltX] = useState(0);
 	const [tiltY, setTiltY] = useState(0);
 
-	function onMove({
-		tiltAngleXPercentage,
-		tiltAngleYPercentage,
-	}: OnMoveParams) {
-		setTiltX(tiltAngleXPercentage);
+	function onMove({ tiltAngleYPercentage }: OnMoveParams) {
 		setTiltY(tiltAngleYPercentage);
 	}
 
@@ -59,7 +57,24 @@ export function ReticleCanvas(props: Props) {
 			scribeVert,
 			defaultFieldWidth,
 			defaultFieldHeight,
+			false,
 		);
+
+		// Trim the reticle to get the true shot size
+		const { width: trimmedFieldWidth, height: trimmedFieldHeight } =
+			getTrimmedFieldDimensions({
+				diesInShotPositions: diesInShot.positions,
+				dieWidth,
+				dieHeight,
+				scribeHoriz,
+				scribeVert,
+				fieldWidth: defaultFieldWidth,
+				fieldHeight: defaultFieldHeight,
+			});
+
+		// Update canvas dimensions
+		canvasEl.current.width = trimmedFieldWidth * props.mmToPxScale;
+		canvasEl.current.height = trimmedFieldHeight * props.mmToPxScale;
 
 		context.fillRect(0, 0, canvasEl.current.width, canvasEl.current.height);
 

--- a/src/components/ReticleCanvas/ReticleCanvas.tsx
+++ b/src/components/ReticleCanvas/ReticleCanvas.tsx
@@ -57,7 +57,6 @@ export function ReticleCanvas(props: Props) {
 			scribeVert,
 			defaultFieldWidth,
 			defaultFieldHeight,
-			false,
 		);
 
 		// Trim the reticle to get the true shot size

--- a/src/components/WaferCanvas/WaferCanvas.tsx
+++ b/src/components/WaferCanvas/WaferCanvas.tsx
@@ -184,8 +184,6 @@ export function WaferCanvas(props: {
 	waferHeight: number;
 	easterEggEnabled: boolean;
 	showShotMap: boolean;
-	fieldWidth: number;
-	fieldHeight: number;
 	validationError?: string;
 }) {
 	const [tiltX, setTiltX] = useState(0);
@@ -245,13 +243,13 @@ export function WaferCanvas(props: {
 					maxDies={maxDies}
 					validationError={props.validationError}
 				/>
-				{props.showShotMap && (
+				{props.showShotMap && props.results && (
 					<ShotMap
 						results={props.results}
 						waferWidth={props.waferWidth}
 						waferHeight={props.waferHeight}
-						fieldWidth={props.fieldWidth}
-						fieldHeight={props.fieldHeight}
+						fieldWidth={props.results.trimmedFieldWidth}
+						fieldHeight={props.results.trimmedFieldHeight}
 					/>
 				)}
 				<LossyEdgeMarker

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -76,7 +76,6 @@ export function useInputs(values: InputValues, options: Options) {
 							yieldModel,
 							fieldWidth,
 							fieldHeight,
-							// Center die on the wafer if Reticle Limit is turned off
 							reticleLimit,
 						),
 					);
@@ -88,7 +87,6 @@ export function useInputs(values: InputValues, options: Options) {
 							yieldModel,
 							fieldWidth,
 							fieldHeight,
-							// Center die on the panel if Reticle Limit is turned off
 							reticleLimit,
 						),
 					);

--- a/src/types/dies.ts
+++ b/src/types/dies.ts
@@ -26,4 +26,6 @@ export type FabResults = null | {
 	partialShotCount: number,
 	reticleUtilization: number,
 	dieCost?: number;
+	trimmedFieldWidth: number;
+	trimmedFieldHeight: number;
 };

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -2,8 +2,10 @@ import {
 	createDieMap,
 	evaluateDiscInputs,
 	getDieStateCounts,
-	getFabYield, getRelativeDiePositions, getTrimmedFieldDimensions,
-	randomNumberSetFromRange
+	getFabYield,
+	getRelativeDiePositions,
+	getTrimmedFieldDimensions,
+	randomNumberSetFromRange,
 } from "./calculations";
 import { yieldModels } from "../config";
 import { DieState } from "../types";
@@ -226,28 +228,15 @@ describe("Calculations", () => {
 			const waferDiameter = 300;
 			const fabYield = 0.75;
 
-			const diesInShot = getRelativeDiePositions(
+			const { diesInShot, trimmedFieldWidth, trimmedFieldHeight } = getRelativeDiePositions(
 				dieEdge,
 				dieEdge,
 				0.2,
 				0.2,
 				26,
 				33,
+				true,
 			);
-
-			// Trim the reticle to get the true shot size
-			const {
-				width: trimmedFieldWidth,
-				height: trimmedFieldHeight
-			} = getTrimmedFieldDimensions({
-				diesInShotPositions: diesInShot.positions,
-				dieWidth: dieEdge,
-				dieHeight: dieEdge,
-				scribeHoriz: 0.2,
-				scribeVert: 0.2,
-				fieldWidth: 26,
-				fieldHeight: 33,
-			});
 
 			// Calculate the reticle shot map
 			const shotPositions = rectanglesInCircle(
@@ -258,7 +247,7 @@ describe("Calculations", () => {
 				0,
 				0,
 				0,
-				true
+				true,
 			);
 
 			const { shotsOnWafer, dies } = createDieMap(
@@ -316,7 +305,7 @@ describe("Calculations", () => {
 				"murphy",
 				26,
 				33,
-				false,
+				true,
 			);
 			const expectedDieArea = 8 * 8;
 			const expectedHorizontalScribeLineAreaPerDie =
@@ -336,37 +325,31 @@ describe("Calculations", () => {
 	});
 
 	describe("getTrimmedFieldDimensions", () => {
-		it ("calculates the trimmed field dimensions correctly", () => {
+		it("calculates the trimmed field dimensions correctly", () => {
 			const dieWidth = 12;
 			const dieHeight = 12;
 			const scribeHoriz = 0.2;
 			const scribeVert = 0.2;
 			const fieldWidth = 26;
 			const fieldHeight = 33;
-			const diesInShot = getRelativeDiePositions(
+			const { trimmedFieldWidth, trimmedFieldHeight } = getRelativeDiePositions(
 				dieWidth,
 				dieHeight,
 				scribeHoriz,
 				scribeVert,
 				fieldWidth,
 				fieldHeight,
+				true,
 			);
 
-			const { width, height } = getTrimmedFieldDimensions({
-				diesInShotPositions: diesInShot.positions,
-				dieWidth,
-				dieHeight,
-				scribeHoriz,
-				scribeVert,
-				fieldWidth,
-				fieldHeight,
-			});
+			const expectedWidth =
+				Math.floor(fieldWidth / (dieWidth + scribeHoriz)) *
+				(dieWidth + scribeHoriz);
+			const expectedHeight =
+				Math.floor(fieldHeight / (12 + scribeVert)) * (dieHeight + scribeVert);
 
-			const expectedWidth = Math.floor(fieldWidth / (dieWidth + scribeHoriz)) * (dieWidth + scribeHoriz);
-			const expectedHeight = Math.floor(fieldHeight / (12 + scribeVert)) * (dieHeight + scribeVert);
-
-			expect(width).toEqual(expectedWidth);
-			expect(height).toEqual(expectedHeight);
-		})
+			expect(trimmedFieldWidth).toEqual(expectedWidth);
+			expect(trimmedFieldHeight).toEqual(expectedHeight);
+		});
 	});
 });

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -334,4 +334,39 @@ describe("Calculations", () => {
 			);
 		});
 	});
+
+	describe("getTrimmedFieldDimensions", () => {
+		it ("calculates the trimmed field dimensions correctly", () => {
+			const dieWidth = 12;
+			const dieHeight = 12;
+			const scribeHoriz = 0.2;
+			const scribeVert = 0.2;
+			const fieldWidth = 26;
+			const fieldHeight = 33;
+			const diesInShot = getRelativeDiePositions(
+				dieWidth,
+				dieHeight,
+				scribeHoriz,
+				scribeVert,
+				fieldWidth,
+				fieldHeight,
+			);
+
+			const { width, height } = getTrimmedFieldDimensions({
+				diesInShotPositions: diesInShot.positions,
+				dieWidth,
+				dieHeight,
+				scribeHoriz,
+				scribeVert,
+				fieldWidth,
+				fieldHeight,
+			});
+
+			const expectedWidth = Math.floor(fieldWidth / (dieWidth + scribeHoriz)) * (dieWidth + scribeHoriz);
+			const expectedHeight = Math.floor(fieldHeight / (12 + scribeVert)) * (dieHeight + scribeVert);
+
+			expect(width).toEqual(expectedWidth);
+			expect(height).toEqual(expectedHeight);
+		})
+	});
 });

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -4,10 +4,9 @@ import {
 	getDieStateCounts,
 	getFabYield,
 	getRelativeDiePositions,
-	getTrimmedFieldDimensions,
 	randomNumberSetFromRange,
 } from "./calculations";
-import { yieldModels } from "../config";
+import { defaultFieldHeight, defaultFieldWidth, yieldModels } from "../config";
 import { DieState } from "../types";
 import {
 	isInsideCircle,
@@ -307,16 +306,9 @@ describe("Calculations", () => {
 				33,
 				true,
 			);
-			const expectedDieArea = 8 * 8;
-			const expectedHorizontalScribeLineAreaPerDie =
-				inputVals.scribeHoriz * inputVals.dieHeight;
-			const expectedVerticalScribeLineAreaPerDie =
-				inputVals.scribeVert * inputVals.dieWidth;
-			const expectedTotalWasteArea =
-				expectedHorizontalScribeLineAreaPerDie +
-				expectedVerticalScribeLineAreaPerDie;
+			const expectedDieArea = 8 * 8 * (result?.diePerCol || 0) * (result?.diePerRow || 0);
 			const expectedReticleUtilization =
-				expectedDieArea / (expectedDieArea + expectedTotalWasteArea);
+				expectedDieArea / (defaultFieldWidth * defaultFieldHeight);
 			expect(result?.reticleUtilization).toBeCloseTo(
 				expectedReticleUtilization,
 				2,
@@ -324,7 +316,7 @@ describe("Calculations", () => {
 		});
 	});
 
-	describe("getTrimmedFieldDimensions", () => {
+	describe("getRelativeDiePositions", () => {
 		it("calculates the trimmed field dimensions correctly", () => {
 			const dieWidth = 12;
 			const dieHeight = 12;

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -2,8 +2,8 @@ import {
 	createDieMap,
 	evaluateDiscInputs,
 	getDieStateCounts,
-	getFabYield,
-	randomNumberSetFromRange,
+	getFabYield, getRelativeDiePositions, getTrimmedFieldDimensions,
+	randomNumberSetFromRange
 } from "./calculations";
 import { yieldModels } from "../config";
 import { DieState } from "../types";
@@ -225,27 +225,40 @@ describe("Calculations", () => {
 			const dieEdge = 12;
 			const waferDiameter = 300;
 			const fabYield = 0.75;
-			const diesInShot = rectanglesInRectangle(
+
+			const diesInShot = getRelativeDiePositions(
+				dieEdge,
+				dieEdge,
+				0.2,
+				0.2,
 				26,
 				33,
-				dieEdge,
-				dieEdge,
-				0.2,
-				0.2,
-				0,
-				0,
-				true,
-				false,
 			);
+
+			// Trim the reticle to get the true shot size
+			const {
+				width: trimmedFieldWidth,
+				height: trimmedFieldHeight
+			} = getTrimmedFieldDimensions({
+				diesInShotPositions: diesInShot.positions,
+				dieWidth: dieEdge,
+				dieHeight: dieEdge,
+				scribeHoriz: 0.2,
+				scribeVert: 0.2,
+				fieldWidth: 26,
+				fieldHeight: 33,
+			});
+
+			// Calculate the reticle shot map
 			const shotPositions = rectanglesInCircle(
 				waferDiameter,
-				26,
-				33,
+				trimmedFieldWidth,
+				trimmedFieldHeight,
 				0,
 				0,
 				0,
 				0,
-				true,
+				true
 			);
 
 			const { shotsOnWafer, dies } = createDieMap(

--- a/src/utils/calculations.test.ts
+++ b/src/utils/calculations.test.ts
@@ -92,9 +92,9 @@ describe("Calculations", () => {
 		it.each(Object.keys(yieldModels))(
 			"returns a full yield if the defect rate is 0 for the %s model",
 			(model) => {
-				expect(getFabYield(0, 1000, model as keyof typeof yieldModels, 1, 100)).toEqual(
-					1,
-				);
+				expect(
+					getFabYield(0, 1000, model as keyof typeof yieldModels, 1, 100),
+				).toEqual(1);
 			},
 		);
 	});
@@ -221,7 +221,7 @@ describe("Calculations", () => {
 			expect(fullShotCount + partialShotCount).toEqual(shotsOnWafer.length);
 		});
 
-		it('shows the correct total number of die based on the number of exposures and the number of dies in a shot', () => {
+		it("shows the correct total number of die based on the number of exposures and the number of dies in a shot", () => {
 			const dieEdge = 12;
 			const waferDiameter = 300;
 			const fabYield = 0.75;
@@ -267,11 +267,16 @@ describe("Calculations", () => {
 				},
 			);
 
-			const excludedDies = dies.filter(die => die.dieState === "lost");
-			const goodDies = dies.filter(die => die.dieState === "good");
-			const defectiveDies = dies.filter(die => die.dieState === "defective");
-			const partialDies = dies.filter(die => die.dieState === "partial");
-			expect(excludedDies.length + goodDies.length + defectiveDies.length + partialDies.length).toEqual(shotsOnWafer.length * diesInShot.numCols * diesInShot.numRows);
+			const excludedDies = dies.filter((die) => die.dieState === "lost");
+			const goodDies = dies.filter((die) => die.dieState === "good");
+			const defectiveDies = dies.filter((die) => die.dieState === "defective");
+			const partialDies = dies.filter((die) => die.dieState === "partial");
+			expect(
+				excludedDies.length +
+					goodDies.length +
+					defectiveDies.length +
+					partialDies.length,
+			).toEqual(shotsOnWafer.length * diesInShot.numCols * diesInShot.numRows);
 		});
 	});
 
@@ -292,8 +297,28 @@ describe("Calculations", () => {
 				criticalLayers: 50,
 				manualYield: 100,
 			};
-			const result = evaluateDiscInputs(inputVals, "s300mm", "murphy", 26, 33, false);
-			expect(result?.reticleUtilization).toBeCloseTo(0.895105, 6);
+			const result = evaluateDiscInputs(
+				inputVals,
+				"s300mm",
+				"murphy",
+				26,
+				33,
+				false,
+			);
+			const expectedDieArea = 8 * 8;
+			const expectedHorizontalScribeLineAreaPerDie =
+				inputVals.scribeHoriz * inputVals.dieHeight;
+			const expectedVerticalScribeLineAreaPerDie =
+				inputVals.scribeVert * inputVals.dieWidth;
+			const expectedTotalWasteArea =
+				expectedHorizontalScribeLineAreaPerDie +
+				expectedVerticalScribeLineAreaPerDie;
+			const expectedReticleUtilization =
+				expectedDieArea / (expectedDieArea + expectedTotalWasteArea);
+			expect(result?.reticleUtilization).toBeCloseTo(
+				expectedReticleUtilization,
+				2,
+			);
 		});
 	});
 });

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -176,11 +176,8 @@ export function getRelativeDiePositions(
 		false
 	);
 
-	let trimmedFieldWidth = fieldWidth;
-	let trimmedFieldHeight = fieldHeight;
-
 	if(trimShotWaste) {
-		// If shot mapping is enabled, trim excess waste area from the shot
+		// Trim excess waste area from the shot and return trimmed dimensions
 		const trimmedFieldDimensions = getTrimmedFieldDimensions({
 			diesInShotPositions: diesInShot.positions,
 			dieWidth,
@@ -191,14 +188,17 @@ export function getRelativeDiePositions(
 			fieldHeight
 		});
 
-		trimmedFieldWidth = trimmedFieldDimensions.width;
-		trimmedFieldHeight = trimmedFieldDimensions.height;
+		return {
+			diesInShot,
+			trimmedFieldWidth: trimmedFieldDimensions.width,
+			trimmedFieldHeight: trimmedFieldDimensions.height
+		}
 	}
 
 	return {
 		diesInShot,
-		trimmedFieldWidth,
-		trimmedFieldHeight,
+		trimmedFieldWidth: fieldWidth,
+		trimmedFieldHeight: fieldHeight,
 	}
 }
 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -432,8 +432,8 @@ export function evaluatePanelInputs(
 		trimmedFieldHeight,
 		0,
 		0,
-		inputVals.scribeHoriz,
-		inputVals.scribeVert,
+		inputVals.transHoriz,
+		inputVals.transVert,
 		true,
 		true
 	).positions;

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -409,7 +409,7 @@ export function evaluatePanelInputs(
 		fieldHeight
 	});
 
-	// First, calculate the reticle shot map
+	// Calculate the reticle shot map
 	const shotPositions = rectanglesInRectangle(
 		width,
 		height,
@@ -417,9 +417,9 @@ export function evaluatePanelInputs(
 		trimmedFieldHeight,
 		0,
 		0,
-		offsetX - fieldWidth / 2,
-		offsetY - fieldHeight / 2,
-		true,
+		offsetX,
+		offsetY,
+		fieldCenteringEnabled,
 		true
 	).positions;
 

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -158,7 +158,6 @@ export function getRelativeDiePositions(
 	scribeVert: number,
 	fieldWidth: number,
 	fieldHeight: number,
-	center: boolean,
 ) {
 	return rectanglesInRectangle(
 		fieldWidth,
@@ -169,7 +168,7 @@ export function getRelativeDiePositions(
 		scribeVert,
 		0,
 		0,
-		center,
+		false,
 		false
 	);
 }
@@ -306,6 +305,11 @@ function getReticleUtilization(
 	return dieAreaPerShot / reticleArea;
 }
 
+/**
+ * Calculate the trimmed field dimensions based on the last (bottom right) die in the shot
+ * @param params object containing die positions, die dimensions, scribe dimensions, and field dimensions
+ * @returns object containing trimmed field width and height
+ */
 export function getTrimmedFieldDimensions(params: {
 	 diesInShotPositions: Array<Position>,
 	 dieWidth: number,
@@ -395,7 +399,6 @@ export function evaluatePanelInputs(
 		scribeVert,
 		fieldWidth,
 		fieldHeight,
-		false
 	);
 
 	// Trim the reticle to get the true shot size
@@ -533,7 +536,6 @@ export function evaluateDiscInputs(
 		scribeVert,
 		fieldWidth,
 		fieldHeight,
-		false
 	);
 
 	// Trim the reticle to get the true shot size

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -1,7 +1,7 @@
 import {
 	waferSizes,
 	panelSizes,
-	yieldModels
+	yieldModels,
 } from "../config";
 import { Die, DieState, FabResults, Position } from "../types";
 import {
@@ -600,8 +600,8 @@ export function evaluateDiscInputs(
 		fullShotCount: dieMap.fullShotCount,
 		partialShotCount: dieMap.partialShotCount,
 		reticleUtilization: getReticleUtilization(
-			trimmedFieldWidth,
-			trimmedFieldHeight,
+			fieldWidth,
+			fieldHeight,
 			dieWidth,
 			dieHeight,
 			diesInShot.positions.length

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -157,7 +157,8 @@ export function getRelativeDiePositions(
 	scribeHoriz: number,
 	scribeVert: number,
 	fieldWidth: number,
-	fieldHeight: number
+	fieldHeight: number,
+	center: boolean,
 ) {
 	return rectanglesInRectangle(
 		fieldWidth,
@@ -168,7 +169,7 @@ export function getRelativeDiePositions(
 		scribeVert,
 		0,
 		0,
-		false,
+		center,
 		false
 	);
 }
@@ -305,7 +306,7 @@ function getReticleUtilization(
 	return dieAreaPerShot / reticleArea;
 }
 
-function getTrimmedFieldDimensions(params: {
+export function getTrimmedFieldDimensions(params: {
 	 diesInShotPositions: Array<Position>,
 	 dieWidth: number,
 	 dieHeight: number,
@@ -385,14 +386,16 @@ export function evaluatePanelInputs(
 		fieldCenteringEnabled
 	);
 
-	// First, calculate the position of dies in a single shot
+	// First, calculate the position of dies in a single shot. Die should NOT be centered
+	// as the shot will be trimmed from the bottom right corner to get the true shot size
 	const diesInShot = getRelativeDiePositions(
 		dieWidth,
 		dieHeight,
 		scribeHoriz,
 		scribeVert,
 		fieldWidth,
-		fieldHeight
+		fieldHeight,
+		false
 	);
 
 	// Trim the reticle to get the true shot size
@@ -521,14 +524,16 @@ export function evaluateDiscInputs(
 		fieldCenteringEnabled
 	);
 
-	// First, calculate the position of dies in a single shot
+	// First, calculate the position of dies in a single shot. Die should NOT be centered
+	// as the shot will be trimmed from the bottom right corner to get the true shot size
 	const diesInShot = getRelativeDiePositions(
 		dieWidth,
 		dieHeight,
 		scribeHoriz,
 		scribeVert,
 		fieldWidth,
-		fieldHeight
+		fieldHeight,
+		false
 	);
 
 	// Trim the reticle to get the true shot size
@@ -545,7 +550,7 @@ export function evaluateDiscInputs(
 		fieldHeight
 	});
 
-	// First, calculate the reticle shot map
+	// Calculate the reticle shot map
 	const shotPositions = rectanglesInCircle(
 		width,
 		trimmedFieldWidth,

--- a/src/utils/geometry.test.ts
+++ b/src/utils/geometry.test.ts
@@ -215,17 +215,17 @@ describe("geometry utils", () => {
 		});
 
 		it("calculates partial overlaps when starting from the center", () => {
-			// Inner squares are 90% the area of the outer square, but we can fit 4 squares
+			// Inner squares are 90% the area of the outer square, but we can fit 9 squares
 			// because we allow partial overlaps
 			expect(
 				rectanglesInRectangle(100, 100, 90, 90, 0, 0, 0, 0, true, true).positions.length
-			).toBe(4);
+			).toBe(9);
 
 			// Inner square is slightly less than 1/3 the size of the outer square, and we
 			// can fit 16 squares because we allow the outer squares to overlap
 			expect(
 				rectanglesInRectangle(70, 70, 20, 20, 0, 0, 0, 0, true, true).positions.length
-			).toBe(16);
+			).toBe(25);
 		});
 
 		it('calculates the correct number of rows and columns', () => {

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -284,8 +284,8 @@ export function rectanglesInRectangle(
 	const halfGapY = gapY / 2;
 
 	// Compute the number of inner rectangles that can fit in each direction
-	const countX = Math.floor(outerRectWidth / effectiveWidth);
-	const countY = Math.floor(outerRectHeight / effectiveHeight);
+	const countX = Math.ceil(outerRectWidth / effectiveWidth);
+	const countY = Math.ceil(outerRectHeight / effectiveHeight);
 
 	// If center alignment is enabled, calculate the padding to center the rectangles
 	let startX = 0;

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -288,8 +288,8 @@ export function rectanglesInRectangle(
 	let countY = Math.floor(outerRectHeight / effectiveHeight);
 
 	// If center alignment is enabled, calculate the padding to center the rectangles
-	let startX = 0;
-	let startY = 0;
+	let startX = halfGapX;
+	let startY = halfGapY;
 	if (center) {
 		// Attempt to fit one more rectangle in each direction when centering is enabled
 		countX += 2;
@@ -306,8 +306,8 @@ export function rectanglesInRectangle(
 	// Iterate through potential positions and calculate coordinates
 	for (let row = 0; row <= countY; row++) {
 		for (let col = 0; col <= countX; col++) {
-			const x = startX + col * effectiveWidth + offsetX + halfGapX;
-			const y = startY + row * effectiveHeight + offsetY + halfGapY;
+			const x = startX + (col * effectiveWidth) + offsetX;
+			const y = startY + (row * effectiveHeight) + offsetY;
 
 			const isInside = rectangleIsInsideRectangle(
 				x,

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -284,13 +284,16 @@ export function rectanglesInRectangle(
 	const halfGapY = gapY / 2;
 
 	// Compute the number of inner rectangles that can fit in each direction
-	const countX = Math.ceil(outerRectWidth / effectiveWidth);
-	const countY = Math.ceil(outerRectHeight / effectiveHeight);
+	let countX = Math.floor(outerRectWidth / effectiveWidth);
+	let countY = Math.floor(outerRectHeight / effectiveHeight);
 
 	// If center alignment is enabled, calculate the padding to center the rectangles
 	let startX = 0;
 	let startY = 0;
 	if (center) {
+		// Attempt to fit one more rectangle in each direction when centering is enabled
+		countX += 2;
+		countY += 2;
 		const totalInnerWidth = countX * effectiveWidth - gapX;
 		const totalInnerHeight = countY * effectiveHeight - gapY;
 		startX = (outerRectWidth - totalInnerWidth) / 2;


### PR DESCRIPTION
**EDIT:** the changes in this branch are now on [the staging site](https://semianalysis-development.mystagingwebsite.com/die-yield-calculator/)

---

This PR adds shot trimming functionality, so that waste area around the die in the reticle is trimmed away before the shot map is calculated, preventing overly large scribe lines from appearing on the wafer. 

- Shots are now a _maximum_ of 26x33mm (26x16.5mm with half-field enabled), rather than being fixed at this size.
- Half of the scribe line width/height is left around the die so that adjacent shots form a full scribe line between die.
- Scribe line labels are updated to remove the 'minimum' wording, as this new behavior guarantees scribe line will have the provided dimensions

[🎥 Loom demo here](https://www.loom.com/share/b23a6a37a1cf40c29b9405335ad10820)

## Screenshots

![Screenshot 2025-05-13 at 17 40 54](https://github.com/user-attachments/assets/557df376-0df8-4ac6-a88e-4161f3bf4b4b)

![Screenshot 2025-05-13 at 17 42 10](https://github.com/user-attachments/assets/6f000a15-bb01-4199-a98e-9326d5ba2c3e)

![Screenshot 2025-05-13 at 17 40 22](https://github.com/user-attachments/assets/9a3cf949-fadf-4088-8cd0-2a3481ade0de)

