### PR TITLE
Auto-optimize checkbox for optimal reticle offset

### DIFF
--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.4.0
+ * Version:           0.4.1
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.4.1
+ * Version:           0.4.2
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.4.2
+ * Version:           0.4.3
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.3.2
+ * Version:           0.4.0
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.3.1",
+	"version": "0.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.3.1",
+			"version": "0.4.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.4.1",
+			"version": "0.4.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.4.2",
+			"version": "0.4.3",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.4.0",
+			"version": "0.4.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -36,6 +36,13 @@ describe("App", () => {
 		});
 		const edgeLossInput = screen.getByRole("spinbutton", { name: /Edge Loss/ });
 
+		// Disable Reticle Limit FIRST to allow full panel coverage
+		await user.click(reticleLimitCheckbox);
+		// Remove Edge Loss to count dice to the edge
+		await user.clear(edgeLossInput);
+		await user.type(edgeLossInput, "0");
+
+		// Now set die dimensions and scribe lines
 		await user.click(maintainAspectRatioCheckbox);
 		await user.clear(widthInput);
 		await user.type(widthInput, "5");
@@ -44,54 +51,27 @@ describe("App", () => {
 		await user.clear(scribeLinesYInput);
 		await user.type(scribeLinesYInput, "0");
 
-		// Disable Reticle Limit to allow full panel coverage
-		await user.click(reticleLimitCheckbox);
-		// Remove Edge Loss to count dice to the edge
-		await user.clear(edgeLossInput);
-		await user.type(edgeLossInput, "0");
+		await waitFor(() => {
+			const totalTextNode = screen.getByText(/Full Dies/);
+			const countStr = within(totalTextNode).getByText(/\d+/);
+			const countMatch = countStr.textContent?.match(/\d+/)?.[0];
+			totalCountNum = countMatch ? parseInt(countMatch) : 0;
 
-		await waitFor(async () => {
-			const totalTextNode = await screen.findByText(/Full Dies/);
+			const excludedTextNode = screen.getByText(/Excluded Dies/);
+			const excludedCountStr = within(excludedTextNode).getByText(/\d+/);
+			const excludedMatch = excludedCountStr.textContent?.match(/\d+/)?.[0];
+			excludedCountNum = excludedMatch ? parseInt(excludedMatch) : 0;
 
-			if (totalTextNode.textContent) {
-				// Wait for the calculation to appear
-				const countStr = await within(totalTextNode).findByText(/\d+/);
-
-				if (countStr.textContent) {
-					const countMatch = countStr.textContent.match(/\d+/)?.[0];
-					totalCountNum = countMatch ? parseInt(countMatch) : 0;
-				}
-			}
-
-			const excludedTextNode = await screen.findByText(/Excluded Dies/);
-
-			if (excludedTextNode.textContent) {
-				// Wait for the calculation to appear
-				const countStr = await within(excludedTextNode).findByText(/\d+/);
-
-				if (countStr.textContent) {
-					const countMatch = countStr.textContent.match(/\d+/)?.[0];
-					excludedCountNum = countMatch ? parseInt(countMatch) : 0;
-				}
-			}
-
-			// Get partial die count as well
-			const partialTextNode = await screen.findByText(/Partial Dies/);
-
-			if (partialTextNode.textContent) {
-				const countStr = await within(partialTextNode).findByText(/\d+/);
-
-				if (countStr.textContent) {
-					const countMatch = countStr.textContent.match(/\d+/)?.[0];
-					partialCountNum = countMatch ? parseInt(countMatch) : 0;
-				}
-			}
+			const partialTextNode = screen.getByText(/Partial Dies/);
+			const partialCountStr = within(partialTextNode).getByText(/\d+/);
+			const partialMatch = partialCountStr.textContent?.match(/\d+/)?.[0];
+			partialCountNum = partialMatch ? parseInt(partialMatch) : 0;
 
 			// How many die can we fit in the entire panel?
 			const expectedTotalDieCount = 300 * 300 / (5 * 5);
 
 			expect(totalCountNum + partialCountNum - excludedCountNum).toEqual(expectedTotalDieCount);
-		}, { timeout: 200 });
+		});
 	});
 
 	it("calculates yields for wafer shape", async () => {

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -304,6 +304,106 @@ describe("App", () => {
 		});
 	});
 
+	it("auto-optimize increases full die count", async () => {
+		render(<App />);
+		const user = userEvent.setup();
+
+		const autoOptimizeCheckbox = screen.getByRole("checkbox", {
+			name: /Auto-optimize die placement/,
+		});
+
+		let fullDiesWithoutOptimization = 0;
+		await waitFor(() => {
+			const fullDiesNode = screen.getByText(/Full Dies/);
+			const countStr = within(fullDiesNode).getByText(/\d+/);
+			const countMatch = countStr.textContent?.match(/\d+/)?.[0];
+			fullDiesWithoutOptimization = countMatch ? parseInt(countMatch) : 0;
+			expect(fullDiesWithoutOptimization).toBeGreaterThan(0);
+		});
+
+		await user.click(autoOptimizeCheckbox);
+		expect(autoOptimizeCheckbox).toBeChecked();
+
+		await waitFor(() => {
+			const fullDiesNode = screen.getByText(/Full Dies/);
+			const countStr = within(fullDiesNode).getByText(/\d+/);
+			const countMatch = countStr.textContent?.match(/\d+/)?.[0];
+			const fullDiesWithOptimization = countMatch ? parseInt(countMatch) : 0;
+			expect(fullDiesWithOptimization).toBeGreaterThan(fullDiesWithoutOptimization);
+		});
+	});
+
+	it("auto-optimize works after validation error is cleared by unchecking reticle limit", async () => {
+		render(<App />);
+		const user = userEvent.setup();
+
+		const dieWidthInput = screen.getByRole("spinbutton", { name: /Width/ });
+		const dieHeightInput = screen.getByRole("spinbutton", { name: /Height/ });
+		const reticleLimitCheckbox = screen.getByRole("checkbox", {
+			name: new RegExp(`Reticle Limit \\(${defaultFieldWidth}mm x ${defaultFieldHeight}mm\\)`),
+		});
+		const autoOptimizeCheckbox = screen.getByRole("checkbox", {
+			name: /Auto-optimize die placement/,
+		});
+		const scribeLinesXInput = screen.getByRole("spinbutton", { name: /Scribe Line X/ });
+		const scribeLinesYInput = screen.getByRole("spinbutton", { name: /Scribe Line Y/ });
+		const edgeLossInput = screen.getByRole("spinbutton", { name: /Edge Loss/ });
+		const notchKeepOutInput = screen.getByRole("spinbutton", { name: /Notch keep-out/ });
+		const waferSizeSelect = screen.getByRole("combobox", { name: /Diameter/ });
+
+		// Try to enter a die size larger than reticle limit, see validation error
+		await user.clear(dieWidthInput);
+		await user.type(dieWidthInput, "45");
+		await user.clear(dieHeightInput);
+		await user.type(dieHeightInput, "45");
+
+		await waitFor(() => {
+			const errorText = screen.getByText(/must be less than or equal to the field/i);
+			expect(errorText).toBeInTheDocument();
+		});
+
+		// Uncheck reticle limit checkbox
+		await user.click(reticleLimitCheckbox);
+		expect(reticleLimitCheckbox).not.toBeChecked();
+
+		// Configure for large die (45x45mm, 0.08mm scribes, 200mm wafer, 5mm edge, 10mm notch)
+		await user.selectOptions(waferSizeSelect, "s200mm");
+		await user.clear(dieWidthInput);
+		await user.type(dieWidthInput, "45");
+		await user.clear(dieHeightInput);
+		await user.type(dieHeightInput, "45");
+		await user.clear(scribeLinesXInput);
+		await user.type(scribeLinesXInput, "0.08");
+		await user.clear(scribeLinesYInput);
+		await user.type(scribeLinesYInput, "0.08");
+		await user.clear(edgeLossInput);
+		await user.type(edgeLossInput, "5");
+		await user.clear(notchKeepOutInput);
+		await user.type(notchKeepOutInput, "10");
+
+		// Ensure we get some full dies
+		let fullDiesBeforeOptimization = 0;
+		await waitFor(() => {
+			const fullDiesNode = screen.getByText(/Full Dies/);
+			const countStr = within(fullDiesNode).getByText(/\d+/);
+			const countMatch = countStr.textContent?.match(/\d+/)?.[0];
+			fullDiesBeforeOptimization = countMatch ? parseInt(countMatch) : 0;
+			expect(fullDiesBeforeOptimization).toBeGreaterThanOrEqual(4);
+		});
+
+		// Check auto-optimize, ensure we get more full dies
+		await user.click(autoOptimizeCheckbox);
+		expect(autoOptimizeCheckbox).toBeChecked();
+
+		await waitFor(() => {
+			const fullDiesNode = screen.getByText(/Full Dies/);
+			const countStr = within(fullDiesNode).getByText(/\d+/);
+			const countMatch = countStr.textContent?.match(/\d+/)?.[0];
+			const fullDiesAfterOptimization = countMatch ? parseInt(countMatch) : 0;
+			expect(fullDiesAfterOptimization).toBeGreaterThan(fullDiesBeforeOptimization);
+		});
+	});
+
 	describe("defects inputs", () => {
 		const yieldModelOptions = [
 			"Poisson Model",

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -312,6 +312,12 @@ describe("App", () => {
 			name: /Auto-optimize die placement/,
 		});
 
+		// Auto-optimize is enabled by default, disable it first
+		expect(autoOptimizeCheckbox).toBeChecked();
+		await user.click(autoOptimizeCheckbox);
+		expect(autoOptimizeCheckbox).not.toBeChecked();
+
+		// Get baseline full dies count without optimization
 		let fullDiesWithoutOptimization = 0;
 		await waitFor(() => {
 			const fullDiesNode = screen.getByText(/Full Dies/);
@@ -321,9 +327,11 @@ describe("App", () => {
 			expect(fullDiesWithoutOptimization).toBeGreaterThan(0);
 		});
 
+		// Re-enable auto-optimize
 		await user.click(autoOptimizeCheckbox);
 		expect(autoOptimizeCheckbox).toBeChecked();
 
+		// Verify full dies count increased
 		await waitFor(() => {
 			const fullDiesNode = screen.getByText(/Full Dies/);
 			const countStr = within(fullDiesNode).getByText(/\d+/);
@@ -350,6 +358,11 @@ describe("App", () => {
 		const edgeLossInput = screen.getByRole("spinbutton", { name: /Edge Loss/ });
 		const notchKeepOutInput = screen.getByRole("spinbutton", { name: /Notch keep-out/ });
 		const waferSizeSelect = screen.getByRole("combobox", { name: /Diameter/ });
+
+		// Auto-optimize is enabled by default, disable it first
+		expect(autoOptimizeCheckbox).toBeChecked();
+		await user.click(autoOptimizeCheckbox);
+		expect(autoOptimizeCheckbox).not.toBeChecked();
 
 		// Try to enter a die size larger than reticle limit, see validation error
 		await user.clear(dieWidthInput);
@@ -381,7 +394,7 @@ describe("App", () => {
 		await user.clear(notchKeepOutInput);
 		await user.type(notchKeepOutInput, "10");
 
-		// Ensure we get some full dies
+		// Ensure we get some full dies without optimization
 		let fullDiesBeforeOptimization = 0;
 		await waitFor(() => {
 			const fullDiesNode = screen.getByText(/Full Dies/);
@@ -391,7 +404,7 @@ describe("App", () => {
 			expect(fullDiesBeforeOptimization).toBeGreaterThanOrEqual(4);
 		});
 
-		// Check auto-optimize, ensure we get more full dies
+		// Re-enable auto-optimize, ensure we get more full dies
 		await user.click(autoOptimizeCheckbox);
 		expect(autoOptimizeCheckbox).toBeChecked();
 

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -13,6 +13,12 @@ describe("App", () => {
 		render(<App />);
 		const user = userEvent.setup();
 
+		// Disable auto-optimize for this test - we're only testing die count calculation
+		const autoOptimizeCheckbox = screen.getByRole("checkbox", {
+			name: /Auto-optimize die placement/,
+		});
+		await user.click(autoOptimizeCheckbox);
+
 		await user.click(
 			screen.getByRole("radio", {
 				name: /Panel/,

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -116,7 +116,7 @@ function App() {
 	const [scribeVert, setScribeVert] = useState<string>("0.2");
 	const [transHoriz, setTransHoriz] = useState<string>("0");
 	const [transVert, setTransVert] = useState<string>("0");
-	const [autoOptimize, setAutoOptimize] = useState(false);
+	const [autoOptimize, setAutoOptimize] = useState(true);
 	const [substrateShape, setSubstrateShape] = useState<SubstrateShape>("Wafer");
 	const [panelSize, setPanelSize] = useState<keyof typeof panelSizes>("s300mm");
 	const [waferSize, setWaferSize] = useState<keyof typeof waferSizes>("s300mm");

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -413,7 +413,6 @@ function App() {
 							label="Auto-optimize die placement"
 							onChange={handleAutoOptimizeChange}
 							checked={autoOptimize}
-							disabled={!reticleLimit}
 						/>
 					</div>
 					<div className="input-row--two-col">

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -18,6 +18,7 @@ import { useEasterEgg } from "../hooks/useEasterEgg";
 import { JumpToResults } from "./JumpToResults/JumpToResults";
 import { clampedInputDisplayValue } from "../utils/inputs";
 import { ReticleCanvas } from "./ReticleCanvas/ReticleCanvas";
+import { optimizeDieOffset } from "../utils/optimization";
 
 const ShapeSelector = (props: {
 	shape: SubstrateShape;
@@ -115,6 +116,7 @@ function App() {
 	const [scribeVert, setScribeVert] = useState<string>("0.2");
 	const [transHoriz, setTransHoriz] = useState<string>("0");
 	const [transVert, setTransVert] = useState<string>("0");
+	const [autoOptimize, setAutoOptimize] = useState(false);
 	const [substrateShape, setSubstrateShape] = useState<SubstrateShape>("Wafer");
 	const [panelSize, setPanelSize] = useState<keyof typeof panelSizes>("s300mm");
 	const [waferSize, setWaferSize] = useState<keyof typeof waferSizes>("s300mm");
@@ -303,6 +305,54 @@ function App() {
 		setHalfField(event.target.checked);
 	};
 
+	const handleAutoOptimizeChange = (
+		event: React.ChangeEvent<HTMLInputElement>,
+	) => {
+		setAutoOptimize(event.target.checked);
+	};
+
+	// Auto-optimize effect - runs when relevant parameters change and auto-optimize is enabled
+	useEffect(() => {
+		if (!autoOptimize || !results || validationError) return;
+
+		const inputVals = {
+			dieWidth: parseFloat(dieWidth),
+			dieHeight: parseFloat(dieHeight),
+			criticalArea: parseFloat(criticalArea),
+			defectRate: parseFloat(defectRate),
+			lossyEdgeWidth: parseFloat(lossyEdgeWidth),
+			notchKeepOutHeight: parseFloat(notchKeepOutHeight),
+			substrateCost: parseFloat(substrateCost),
+			scribeHoriz: parseFloat(scribeHoriz),
+			scribeVert: parseFloat(scribeVert),
+			transHoriz: parseFloat(transHoriz),
+			transVert: parseFloat(transVert),
+			criticalLayers: parseFloat(criticalLayers),
+			manualYield: parseFloat(manualYield),
+		};
+
+		const options = {
+			yieldModel: selectedModel,
+			substrateShape,
+			panelSize,
+			discSize: waferSize,
+			fieldWidth: fieldWidthMM,
+			fieldHeight: fieldHeightMM,
+			reticleLimit,
+		};
+
+		const { optimalTransHoriz, optimalTransVert } = optimizeDieOffset(inputVals, options);
+
+		// Only update if the optimal values are significantly different
+		const horizontalDiff = Math.abs(optimalTransHoriz - inputVals.transHoriz);
+		const verticalDiff = Math.abs(optimalTransVert - inputVals.transVert);
+
+		if (horizontalDiff > 0.001 || verticalDiff > 0.001) {
+			setTransHoriz(optimalTransHoriz.toString());
+			setTransVert(optimalTransVert.toString());
+		}
+	}, [autoOptimize, results, validationError]);
+
 	return (
 		<div className="container">
 			<div className="columns">
@@ -359,17 +409,25 @@ function App() {
 							checked={halfField}
 							disabled={!reticleLimit}
 						/>
+						<Checkbox
+							label="Auto-optimize die placement"
+							onChange={handleAutoOptimizeChange}
+							checked={autoOptimize}
+							disabled={!reticleLimit}
+						/>
 					</div>
 					<div className="input-row--two-col">
 						<NumberInput
 							label="Reticle Offset Horizontal (mm)"
 							value={transHoriz}
 							onChange={(event) => setTransHoriz(event.target.value)}
+							isDisabled={autoOptimize}
 						/>
 						<NumberInput
 							label="Reticle Offset Vertical (mm)"
 							value={transVert}
 							onChange={(event) => setTransVert(event.target.value)}
+							isDisabled={autoOptimize}
 						/>
 					</div>
 					<hr />

--- a/src/edit.js
+++ b/src/edit.js
@@ -1,11 +1,4 @@
 /**
- * Retrieves the translation of text.
- *
- * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-i18n/
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * React hook that is used to mark the block wrapper element.
  * It provides all the necessary props like the class name.
  *

--- a/src/hooks/useInputs.ts
+++ b/src/hooks/useInputs.ts
@@ -68,6 +68,7 @@ export function useInputs(values: InputValues, options: Options) {
 				setResults(null);
 				setValidationError(validationErrors[0]);
 			} else {
+				setValidationError(undefined);
 				if (substrateShape === "Wafer") {
 					setResults(
 						evaluateDiscInputs(

--- a/src/utils/optimization.test.ts
+++ b/src/utils/optimization.test.ts
@@ -177,11 +177,12 @@ describe("optimizeDieOffset", () => {
 	});
 
 	describe("Silicon Edge DYC benchmark comparison", () => {
-		// Silicon Edge benchmark values (DPW) fetched from:
-		// https://www.silicon-edge.co.uk/toys/dpw/wafer_png.php
+		// Silicon Edge benchmark DPW values fetched from:
+		// https://www.silicon-edge.co.uk/j/index.php/resources/die-per-wafer
+		// We should match or exceed these values.
 
-		it("matches Silicon Edge benchmark for 9.2x9.6mm die", () => {
-			const siliconEdgeDPW = 712;
+		it("matches/beats Silicon Edge benchmark for 9.2x9.6mm die, 0.1mm scribe lines", () => {
+			const siliconEdgeDPW = 697;
 
 			const inputValues: InputValues = {
 				dieWidth: 9.2,
@@ -189,10 +190,10 @@ describe("optimizeDieOffset", () => {
 				criticalArea: 88.32,
 				defectRate: 0,
 				lossyEdgeWidth: 3,
-				notchKeepOutHeight: 0,
+				notchKeepOutHeight: 5,
 				substrateCost: 20000,
-				scribeHoriz: 0,
-				scribeVert: 0,
+				scribeHoriz: 0.1,
+				scribeVert: 0.1,
 				transHoriz: 0,
 				transVert: 0,
 				criticalLayers: 25,
@@ -204,8 +205,8 @@ describe("optimizeDieOffset", () => {
 			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 		});
 
-		it("matches Silicon Edge benchmark for 10x10mm die", () => {
-			const siliconEdgeDPW = 625;
+		it("matches/beats Silicon Edge benchmark for 10x10mm die, 0.1mm scribes", () => {
+			const siliconEdgeDPW = 612;
 
 			const inputValues: InputValues = {
 				dieWidth: 10,
@@ -213,10 +214,10 @@ describe("optimizeDieOffset", () => {
 				criticalArea: 100,
 				defectRate: 0,
 				lossyEdgeWidth: 3,
-				notchKeepOutHeight: 0,
+				notchKeepOutHeight: 5,
 				substrateCost: 20000,
-				scribeHoriz: 0,
-				scribeVert: 0,
+				scribeHoriz: 0.1,
+				scribeVert: 0.1,
 				transHoriz: 0,
 				transVert: 0,
 				criticalLayers: 25,
@@ -228,7 +229,7 @@ describe("optimizeDieOffset", () => {
 			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 		});
 
-		it("matches Silicon Edge benchmark for 12x12mm die", () => {
+		it("matches/beats Silicon Edge benchmark for 12x12mm die, no scribe line", () => {
 			const siliconEdgeDPW = 432;
 
 			const inputValues: InputValues = {
@@ -237,7 +238,7 @@ describe("optimizeDieOffset", () => {
 				criticalArea: 144,
 				defectRate: 0,
 				lossyEdgeWidth: 3,
-				notchKeepOutHeight: 0,
+				notchKeepOutHeight: 5,
 				substrateCost: 20000,
 				scribeHoriz: 0,
 				scribeVert: 0,
@@ -252,7 +253,7 @@ describe("optimizeDieOffset", () => {
 			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 		});
 
-		it("matches Silicon Edge benchmark for 8x16mm die", () => {
+		it("matches/beats Silicon Edge benchmark for 8x16mm die, no scribe line", () => {
 			const siliconEdgeDPW = 481;
 
 			const inputValues: InputValues = {
@@ -261,7 +262,7 @@ describe("optimizeDieOffset", () => {
 				criticalArea: 128,
 				defectRate: 0,
 				lossyEdgeWidth: 3,
-				notchKeepOutHeight: 0,
+				notchKeepOutHeight: 5,
 				substrateCost: 20000,
 				scribeHoriz: 0,
 				scribeVert: 0,
@@ -276,19 +277,43 @@ describe("optimizeDieOffset", () => {
 			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 		});
 
-		it("matches Silicon Edge benchmark for 15x15mm die with scribe lines and notch", () => {
-			const siliconEdgeDPW = 261;
+		it("matches/beats Silicon Edge benchmark for 15x15mm die, 1mm scribe lines, 10mm notch, 5mm edge", () => {
+			const siliconEdgeDPW = 229;
 
 			const inputValues: InputValues = {
 				dieWidth: 15,
 				dieHeight: 15,
 				criticalArea: 225,
 				defectRate: 0,
+				lossyEdgeWidth: 5,
+				notchKeepOutHeight: 10,
+				substrateCost: 20000,
+				scribeHoriz: 1,
+				scribeVert: 1,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+
+		it("matches/beats Silicon Edge benchmark for 2x6mm die, 0.08mm scribe lines", () => {
+			const siliconEdgeDPW = 5186;
+
+			const inputValues: InputValues = {
+				dieWidth: 2,
+				dieHeight: 6,
+				criticalArea: 225,
+				defectRate: 0,
 				lossyEdgeWidth: 3,
 				notchKeepOutHeight: 5,
 				substrateCost: 20000,
-				scribeHoriz: 0.2,
-				scribeVert: 0.2,
+				scribeHoriz: 0.08,
+				scribeVert: 0.08,
 				transHoriz: 0,
 				transVert: 0,
 				criticalLayers: 25,

--- a/src/utils/optimization.test.ts
+++ b/src/utils/optimization.test.ts
@@ -128,31 +128,6 @@ describe("optimizeDieOffset", () => {
 	});
 
 	describe("optimization characteristics", () => {
-		it("returns offsets within valid range [0, die dimension]", () => {
-			const inputValues: InputValues = {
-				dieWidth: 9.2,
-				dieHeight: 9.6,
-				criticalArea: 88.32,
-				defectRate: 0.1,
-				lossyEdgeWidth: 3,
-				notchKeepOutHeight: 5,
-				substrateCost: 20000,
-				scribeHoriz: 0.2,
-				scribeVert: 0.2,
-				transHoriz: 0,
-				transVert: 0,
-				criticalLayers: 25,
-				manualYield: 100,
-			};
-
-			const result = optimizeDieOffset(inputValues, baseOptions);
-
-			expect(result.optimalTransHoriz).toBeGreaterThanOrEqual(0);
-			expect(result.optimalTransHoriz).toBeLessThanOrEqual(inputValues.dieWidth);
-			expect(result.optimalTransVert).toBeGreaterThanOrEqual(0);
-			expect(result.optimalTransVert).toBeLessThanOrEqual(inputValues.dieHeight);
-		});
-
 		it("returns a positive number of good dies", () => {
 			const inputValues: InputValues = {
 				dieWidth: 9.2,
@@ -324,5 +299,65 @@ describe("optimizeDieOffset", () => {
 
 			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 		});
+	});
+
+
+	it("matches/beats Silicon Edge benchmark for 67.7x60.5mm die, 0.08mm scribes, 5mm edge, 10mm notch", () => {
+		const siliconEdgeDPW = 10;
+
+		const inputValues: InputValues = {
+			dieWidth: 67.7,
+			dieHeight: 60.5,
+			criticalArea: 4095.85,
+			defectRate: 0,
+			lossyEdgeWidth: 5,
+			notchKeepOutHeight: 10,
+			substrateCost: 20000,
+			scribeHoriz: 0.08,
+			scribeVert: 0.08,
+			transHoriz: 0,
+			transVert: 0,
+			criticalLayers: 25,
+			manualYield: 100,
+		};
+
+		const optimizationResult = optimizeDieOffset(inputValues, {
+			...baseOptions,
+			reticleLimit: false,
+			fieldHeight: 300,
+			fieldWidth: 300,
+		});
+
+		expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+	});
+
+	it("matches/beats Silicon Edge benchmark for 200mm wafer, 45x45mm die, 0.08mm scribes, 5mm edge, 10mm notch", () => {
+		const siliconEdgeDPW = 8;
+
+		const inputValues: InputValues = {
+			dieWidth: 45,
+			dieHeight: 45,
+			criticalArea: 2025,
+			defectRate: 0,
+			lossyEdgeWidth: 5,
+			notchKeepOutHeight: 10,
+			substrateCost: 20000,
+			scribeHoriz: 0.08,
+			scribeVert: 0.08,
+			transHoriz: 0,
+			transVert: 0,
+			criticalLayers: 25,
+			manualYield: 100,
+		};
+
+		const optimizationResult = optimizeDieOffset(inputValues, {
+			...baseOptions,
+			discSize: "s200mm",
+			reticleLimit: false,
+			fieldHeight: 200,
+			fieldWidth: 200,
+		});
+
+		expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
 	});
 });

--- a/src/utils/optimization.test.ts
+++ b/src/utils/optimization.test.ts
@@ -1,0 +1,303 @@
+import { optimizeDieOffset } from "./optimization";
+import { evaluateDiscInputs, InputValues } from "./calculations";
+
+describe("optimizeDieOffset", () => {
+	const baseOptions = {
+		discSize: "s300mm" as const,
+		fieldHeight: 33,
+		fieldWidth: 26,
+		panelSize: "s300mm" as const,
+		reticleLimit: true,
+		substrateShape: "Wafer" as const,
+		yieldModel: "murphy" as const,
+	};
+
+	describe("optimization effectiveness", () => {
+		it("produces equal or better results than non-optimized placement", () => {
+			const inputValues: InputValues = {
+				dieWidth: 9.2,
+				dieHeight: 9.6,
+				criticalArea: 88.32,
+				defectRate: 0.1,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 5,
+				substrateCost: 20000,
+				scribeHoriz: 0.2,
+				scribeVert: 0.2,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const nonOptimizedResult = evaluateDiscInputs(
+				inputValues,
+				baseOptions.discSize,
+				baseOptions.yieldModel,
+				baseOptions.fieldWidth,
+				baseOptions.fieldHeight,
+				baseOptions.reticleLimit,
+			);
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(
+				nonOptimizedResult?.goodDies || 0,
+			);
+		});
+
+		it("finds optimal offsets for different die sizes", () => {
+			const testCases = [
+				{ dieWidth: 8, dieHeight: 8 },
+				{ dieWidth: 10, dieHeight: 12 },
+				{ dieWidth: 15, dieHeight: 15 },
+			];
+
+			testCases.forEach(({ dieWidth, dieHeight }) => {
+				const inputValues: InputValues = {
+					dieWidth,
+					dieHeight,
+					criticalArea: dieWidth * dieHeight,
+					defectRate: 0.1,
+					lossyEdgeWidth: 3,
+					notchKeepOutHeight: 5,
+					substrateCost: 20000,
+					scribeHoriz: 0.2,
+					scribeVert: 0.2,
+					transHoriz: 0,
+					transVert: 0,
+					criticalLayers: 25,
+					manualYield: 100,
+				};
+
+				const nonOptimizedResult = evaluateDiscInputs(
+					inputValues,
+					baseOptions.discSize,
+					baseOptions.yieldModel,
+					baseOptions.fieldWidth,
+					baseOptions.fieldHeight,
+					baseOptions.reticleLimit,
+				);
+
+				const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+				expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(
+					nonOptimizedResult?.goodDies || 0,
+				);
+			});
+		});
+
+		it("handles different wafer sizes", () => {
+			const waferSizes = ["s200mm", "s300mm", "s450mm"] as const;
+
+			waferSizes.forEach((discSize) => {
+				const inputValues: InputValues = {
+					dieWidth: 10,
+					dieHeight: 10,
+					criticalArea: 100,
+					defectRate: 0.1,
+					lossyEdgeWidth: 3,
+					notchKeepOutHeight: 5,
+					substrateCost: 20000,
+					scribeHoriz: 0.2,
+					scribeVert: 0.2,
+					transHoriz: 0,
+					transVert: 0,
+					criticalLayers: 25,
+					manualYield: 100,
+				};
+
+				const options = { ...baseOptions, discSize };
+
+				const nonOptimizedResult = evaluateDiscInputs(
+					inputValues,
+					discSize,
+					options.yieldModel,
+					options.fieldWidth,
+					options.fieldHeight,
+					options.reticleLimit,
+				);
+
+				const optimizationResult = optimizeDieOffset(inputValues, options);
+
+				expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(
+					nonOptimizedResult?.goodDies || 0,
+				);
+			});
+		});
+	});
+
+	describe("optimization characteristics", () => {
+		it("returns offsets within valid range [0, die dimension]", () => {
+			const inputValues: InputValues = {
+				dieWidth: 9.2,
+				dieHeight: 9.6,
+				criticalArea: 88.32,
+				defectRate: 0.1,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 5,
+				substrateCost: 20000,
+				scribeHoriz: 0.2,
+				scribeVert: 0.2,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const result = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(result.optimalTransHoriz).toBeGreaterThanOrEqual(0);
+			expect(result.optimalTransHoriz).toBeLessThanOrEqual(inputValues.dieWidth);
+			expect(result.optimalTransVert).toBeGreaterThanOrEqual(0);
+			expect(result.optimalTransVert).toBeLessThanOrEqual(inputValues.dieHeight);
+		});
+
+		it("returns a positive number of good dies", () => {
+			const inputValues: InputValues = {
+				dieWidth: 9.2,
+				dieHeight: 9.6,
+				criticalArea: 88.32,
+				defectRate: 0.1,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 5,
+				substrateCost: 20000,
+				scribeHoriz: 0.2,
+				scribeVert: 0.2,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const result = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(result.maxGoodDies).toBeGreaterThan(0);
+		});
+	});
+
+	describe("Silicon Edge DYC benchmark comparison", () => {
+		// Silicon Edge benchmark values (DPW) fetched from:
+		// https://www.silicon-edge.co.uk/toys/dpw/wafer_png.php
+
+		it("matches Silicon Edge benchmark for 9.2x9.6mm die", () => {
+			const siliconEdgeDPW = 712;
+
+			const inputValues: InputValues = {
+				dieWidth: 9.2,
+				dieHeight: 9.6,
+				criticalArea: 88.32,
+				defectRate: 0,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 0,
+				substrateCost: 20000,
+				scribeHoriz: 0,
+				scribeVert: 0,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+
+		it("matches Silicon Edge benchmark for 10x10mm die", () => {
+			const siliconEdgeDPW = 625;
+
+			const inputValues: InputValues = {
+				dieWidth: 10,
+				dieHeight: 10,
+				criticalArea: 100,
+				defectRate: 0,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 0,
+				substrateCost: 20000,
+				scribeHoriz: 0,
+				scribeVert: 0,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+
+		it("matches Silicon Edge benchmark for 12x12mm die", () => {
+			const siliconEdgeDPW = 432;
+
+			const inputValues: InputValues = {
+				dieWidth: 12,
+				dieHeight: 12,
+				criticalArea: 144,
+				defectRate: 0,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 0,
+				substrateCost: 20000,
+				scribeHoriz: 0,
+				scribeVert: 0,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+
+		it("matches Silicon Edge benchmark for 8x16mm die", () => {
+			const siliconEdgeDPW = 481;
+
+			const inputValues: InputValues = {
+				dieWidth: 8,
+				dieHeight: 16,
+				criticalArea: 128,
+				defectRate: 0,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 0,
+				substrateCost: 20000,
+				scribeHoriz: 0,
+				scribeVert: 0,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+
+		it("matches Silicon Edge benchmark for 15x15mm die with scribe lines and notch", () => {
+			const siliconEdgeDPW = 261;
+
+			const inputValues: InputValues = {
+				dieWidth: 15,
+				dieHeight: 15,
+				criticalArea: 225,
+				defectRate: 0,
+				lossyEdgeWidth: 3,
+				notchKeepOutHeight: 5,
+				substrateCost: 20000,
+				scribeHoriz: 0.2,
+				scribeVert: 0.2,
+				transHoriz: 0,
+				transVert: 0,
+				criticalLayers: 25,
+				manualYield: 100,
+			};
+
+			const optimizationResult = optimizeDieOffset(inputValues, baseOptions);
+
+			expect(optimizationResult.maxGoodDies).toBeGreaterThanOrEqual(siliconEdgeDPW);
+		});
+	});
+});

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -22,62 +22,85 @@ interface OptimizationResult {
 	maxGoodDies: number;
 }
 
+/**
+ * Evaluate a single offset configuration and return the number of good dies
+ */
+function evaluateOffset(
+	values: InputValues,
+	options: OptimizationOptions
+): number {
+	let result;
+	if (options.substrateShape === "Wafer") {
+		result = evaluateDiscInputs(
+			values,
+			options.discSize,
+			options.yieldModel,
+			options.fieldWidth,
+			options.fieldHeight,
+			options.reticleLimit
+		);
+	} else {
+		result = evaluatePanelInputs(
+			values,
+			options.panelSize,
+			options.yieldModel,
+			options.fieldWidth,
+			options.fieldHeight,
+			options.reticleLimit
+		);
+	}
+	return result ? result.goodDies : 0;
+}
+
 export function optimizeDieOffset(
 	values: InputValues,
 	options: OptimizationOptions
 ): OptimizationResult {
 	const { dieWidth, dieHeight } = values;
 
-	// Define search ranges: -0.5 to +0.5 die width/height
-	const horizontalRange = [-0.5 * dieWidth, 0.5 * dieWidth];
-	const verticalRange = [-0.5 * dieHeight, 0.5 * dieHeight];
+	// Offset is periodic with period equal to die dimensions
+	const horizontalRange = [0, dieWidth];
+	const verticalRange = [0, dieHeight];
 
-	// Use step size that balances precision with performance (0.1 die width/height)
-	const horizontalStep = dieWidth * 0.1;
-	const verticalStep = dieHeight * 0.1;
+	// Step size precision
+	const horizontalStep = Math.min(0.1, dieWidth * 0.1);
+	const verticalStep = Math.min(0.1, dieWidth * 0.1);
 
 	let maxGoodDies = 0;
 	let optimalTransHoriz = values.transHoriz;
 	let optimalTransVert = values.transVert;
 
-	// Iterate through the offset range
+	// Optimize one dimension at a time (X then Y):
+
+	// Step 1: Optimize horizontal offset while keeping vertical constant
 	for (let transHoriz = horizontalRange[0]; transHoriz <= horizontalRange[1]; transHoriz += horizontalStep) {
-		for (let transVert = verticalRange[0]; transVert <= verticalRange[1]; transVert += verticalStep) {
-			// Create new input values with current offset
-			const testValues: InputValues = {
-				...values,
-				transHoriz: parseFloat(transHoriz.toFixed(3)),
-				transVert: parseFloat(transVert.toFixed(3))
-			};
+		const testValues: InputValues = {
+			...values,
+			transHoriz: parseFloat(transHoriz.toFixed(3)),
+			transVert: values.transVert
+		};
 
-			// Calculate results for these offset values
-			let result;
-			if (options.substrateShape === "Wafer") {
-				result = evaluateDiscInputs(
-					testValues,
-					options.discSize,
-					options.yieldModel,
-					options.fieldWidth,
-					options.fieldHeight,
-					options.reticleLimit
-				);
-			} else {
-				result = evaluatePanelInputs(
-					testValues,
-					options.panelSize,
-					options.yieldModel,
-					options.fieldWidth,
-					options.fieldHeight,
-					options.reticleLimit
-				);
-			}
+		const goodDies = evaluateOffset(testValues, options);
 
-			// Check if this configuration produces more good dies
-			if (result && result.goodDies > maxGoodDies) {
-				maxGoodDies = result.goodDies;
-				optimalTransHoriz = testValues.transHoriz;
-				optimalTransVert = testValues.transVert;
-			}
+		if (goodDies > maxGoodDies) {
+			maxGoodDies = goodDies;
+			optimalTransHoriz = testValues.transHoriz;
+		}
+	}
+
+	// Step 2: Optimize vertical offset using the optimal horizontal offset
+	for (let transVert = verticalRange[0]; transVert <= verticalRange[1]; transVert += verticalStep) {
+		const testValues: InputValues = {
+			...values,
+			transHoriz: optimalTransHoriz,
+			transVert: parseFloat(transVert.toFixed(3))
+		};
+
+		const goodDies = evaluateOffset(testValues, options);
+
+		if (goodDies > maxGoodDies) {
+			maxGoodDies = goodDies;
+			optimalTransVert = testValues.transVert;
 		}
 	}
 

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -65,8 +65,8 @@ export function optimizeDieOffset(
 	// Stage 1: Coarse grid search with 0.5mm step
 	const coarseStep = 0.5;
 
-	for (let transVert = 0; transVert <= dieHeight; transVert += coarseStep) {
-		for (let transHoriz = 0; transHoriz <= dieWidth; transHoriz += coarseStep) {
+	for (let transVert = -0.75 * dieHeight; transVert <= 0.75 * dieHeight; transVert += coarseStep) {
+		for (let transHoriz = -0.75 * dieWidth; transHoriz <= 0.75 * dieWidth; transHoriz += coarseStep) {
 			const testValues: InputValues = {
 				...values,
 				transHoriz: parseFloat(transHoriz.toFixed(3)),
@@ -85,12 +85,12 @@ export function optimizeDieOffset(
 
 	// Stage 2: Fine grid search with 0.1mm step around coarse optimum
 	const fineStep = 0.1;
-	const fineRadius = 0.5;
+	const fineRadius = 1;
 
-	const fineHorizMin = Math.max(0, optimalTransHoriz - fineRadius);
-	const fineHorizMax = Math.min(dieWidth, optimalTransHoriz + fineRadius);
-	const fineVertMin = Math.max(0, optimalTransVert - fineRadius);
-	const fineVertMax = Math.min(dieHeight, optimalTransVert + fineRadius);
+	const fineHorizMin = optimalTransHoriz - fineRadius;
+	const fineHorizMax = optimalTransHoriz + fineRadius;
+	const fineVertMin = optimalTransVert - fineRadius;
+	const fineVertMax = optimalTransVert + fineRadius;
 
 	for (let transVert = fineVertMin; transVert <= fineVertMax; transVert += fineStep) {
 		for (let transHoriz = fineHorizMin; transHoriz <= fineHorizMax; transHoriz += fineStep) {

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -58,49 +58,55 @@ export function optimizeDieOffset(
 ): OptimizationResult {
 	const { dieWidth, dieHeight } = values;
 
-	// Offset is periodic with period equal to die dimensions
-	const horizontalRange = [0, dieWidth];
-	const verticalRange = [0, dieHeight];
-
-	// Step size precision
-	const horizontalStep = Math.min(0.1, dieWidth * 0.1);
-	const verticalStep = Math.min(0.1, dieWidth * 0.1);
-
 	let maxGoodDies = 0;
 	let optimalTransHoriz = values.transHoriz;
 	let optimalTransVert = values.transVert;
 
-	// Optimize one dimension at a time (X then Y):
+	// Stage 1: Coarse grid search with 0.5mm step
+	const coarseStep = 0.5;
 
-	// Step 1: Optimize horizontal offset while keeping vertical constant
-	for (let transHoriz = horizontalRange[0]; transHoriz <= horizontalRange[1]; transHoriz += horizontalStep) {
-		const testValues: InputValues = {
-			...values,
-			transHoriz: parseFloat(transHoriz.toFixed(3)),
-			transVert: values.transVert
-		};
+	for (let transVert = 0; transVert <= dieHeight; transVert += coarseStep) {
+		for (let transHoriz = 0; transHoriz <= dieWidth; transHoriz += coarseStep) {
+			const testValues: InputValues = {
+				...values,
+				transHoriz: parseFloat(transHoriz.toFixed(3)),
+				transVert: parseFloat(transVert.toFixed(3))
+			};
 
-		const goodDies = evaluateOffset(testValues, options);
+			const goodDies = evaluateOffset(testValues, options);
 
-		if (goodDies > maxGoodDies) {
-			maxGoodDies = goodDies;
-			optimalTransHoriz = testValues.transHoriz;
+			if (goodDies > maxGoodDies) {
+				maxGoodDies = goodDies;
+				optimalTransHoriz = testValues.transHoriz;
+				optimalTransVert = testValues.transVert;
+			}
 		}
 	}
 
-	// Step 2: Optimize vertical offset using the optimal horizontal offset
-	for (let transVert = verticalRange[0]; transVert <= verticalRange[1]; transVert += verticalStep) {
-		const testValues: InputValues = {
-			...values,
-			transHoriz: optimalTransHoriz,
-			transVert: parseFloat(transVert.toFixed(3))
-		};
+	// Stage 2: Fine grid search with 0.1mm step around coarse optimum
+	const fineStep = 0.1;
+	const fineRadius = 0.5;
 
-		const goodDies = evaluateOffset(testValues, options);
+	const fineHorizMin = Math.max(0, optimalTransHoriz - fineRadius);
+	const fineHorizMax = Math.min(dieWidth, optimalTransHoriz + fineRadius);
+	const fineVertMin = Math.max(0, optimalTransVert - fineRadius);
+	const fineVertMax = Math.min(dieHeight, optimalTransVert + fineRadius);
 
-		if (goodDies > maxGoodDies) {
-			maxGoodDies = goodDies;
-			optimalTransVert = testValues.transVert;
+	for (let transVert = fineVertMin; transVert <= fineVertMax; transVert += fineStep) {
+		for (let transHoriz = fineHorizMin; transHoriz <= fineHorizMax; transHoriz += fineStep) {
+			const testValues: InputValues = {
+				...values,
+				transHoriz: parseFloat(transHoriz.toFixed(3)),
+				transVert: parseFloat(transVert.toFixed(3))
+			};
+
+			const goodDies = evaluateOffset(testValues, options);
+
+			if (goodDies > maxGoodDies) {
+				maxGoodDies = goodDies;
+				optimalTransHoriz = testValues.transHoriz;
+				optimalTransVert = testValues.transVert;
+			}
 		}
 	}
 

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -1,0 +1,89 @@
+import { SubstrateShape } from "../types";
+import { waferSizes, panelSizes, yieldModels } from "../config";
+import {
+	evaluateDiscInputs,
+	evaluatePanelInputs,
+	InputValues,
+} from "./calculations";
+
+interface OptimizationOptions {
+	discSize: keyof typeof waferSizes;
+	fieldHeight: number;
+	fieldWidth: number;
+	panelSize: keyof typeof panelSizes;
+	reticleLimit: boolean;
+	substrateShape: SubstrateShape;
+	yieldModel: keyof typeof yieldModels;
+}
+
+interface OptimizationResult {
+	optimalTransHoriz: number;
+	optimalTransVert: number;
+	maxGoodDies: number;
+}
+
+export function optimizeDieOffset(
+	values: InputValues,
+	options: OptimizationOptions
+): OptimizationResult {
+	const { dieWidth, dieHeight } = values;
+
+	// Define search ranges: -0.5 to +0.5 die width/height
+	const horizontalRange = [-0.5 * dieWidth, 0.5 * dieWidth];
+	const verticalRange = [-0.5 * dieHeight, 0.5 * dieHeight];
+
+	// Use step size that balances precision with performance (0.1 die width/height)
+	const horizontalStep = dieWidth * 0.1;
+	const verticalStep = dieHeight * 0.1;
+
+	let maxGoodDies = 0;
+	let optimalTransHoriz = values.transHoriz;
+	let optimalTransVert = values.transVert;
+
+	// Iterate through the offset range
+	for (let transHoriz = horizontalRange[0]; transHoriz <= horizontalRange[1]; transHoriz += horizontalStep) {
+		for (let transVert = verticalRange[0]; transVert <= verticalRange[1]; transVert += verticalStep) {
+			// Create new input values with current offset
+			const testValues: InputValues = {
+				...values,
+				transHoriz: parseFloat(transHoriz.toFixed(3)),
+				transVert: parseFloat(transVert.toFixed(3))
+			};
+
+			// Calculate results for these offset values
+			let result;
+			if (options.substrateShape === "Wafer") {
+				result = evaluateDiscInputs(
+					testValues,
+					options.discSize,
+					options.yieldModel,
+					options.fieldWidth,
+					options.fieldHeight,
+					options.reticleLimit
+				);
+			} else {
+				result = evaluatePanelInputs(
+					testValues,
+					options.panelSize,
+					options.yieldModel,
+					options.fieldWidth,
+					options.fieldHeight,
+					options.reticleLimit
+				);
+			}
+
+			// Check if this configuration produces more good dies
+			if (result && result.goodDies > maxGoodDies) {
+				maxGoodDies = result.goodDies;
+				optimalTransHoriz = testValues.transHoriz;
+				optimalTransVert = testValues.transVert;
+			}
+		}
+	}
+
+	return {
+		optimalTransHoriz,
+		optimalTransVert,
+		maxGoodDies
+	};
+}

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -62,11 +62,12 @@ export function optimizeDieOffset(
 	let optimalTransHoriz = values.transHoriz;
 	let optimalTransVert = values.transVert;
 
-	// Stage 1: Coarse grid search with 0.5mm step
+	// Stage 1: Coarse grid search with 0.5mm step. Go from minus die width/height
+	// to plus die width/height
 	const coarseStep = 0.5;
 
-	for (let transVert = -0.75 * dieHeight; transVert <= 0.75 * dieHeight; transVert += coarseStep) {
-		for (let transHoriz = -0.75 * dieWidth; transHoriz <= 0.75 * dieWidth; transHoriz += coarseStep) {
+	for (let transVert = -0.5 * dieHeight; transVert <= 0.5 * dieHeight; transVert += coarseStep) {
+		for (let transHoriz = -0.5 * dieWidth; transHoriz <= 0.5 * dieWidth; transHoriz += coarseStep) {
 			const testValues: InputValues = {
 				...values,
 				transHoriz: parseFloat(transHoriz.toFixed(3)),


### PR DESCRIPTION
🎥 [Loom walkthrough](https://www.loom.com/share/9af14b00a7514d8e9e765d4d2113b8ba)
🔗 [Staging demo](https://semianalysis-development.mystagingwebsite.com/die-yield-calculator/)

This PR introduces an 'auto-optimize' checkbox (unchecked by default) which, when checked, automatically finds the optimal X and Y offset values in order to maximize die yield.

The implementation works by looping through a range of offset values in a coarse -> fine approach, choosing the X/Y combination that results in the highest 'max good die' number.

The PR includes a number of unit tests to assert correctness, including benchmarking tests against the [Silicon Edge](https://www.silicon-edge.co.uk/j/index.php/resources/die-per-wafer) tool for a number of arbitrary input values, asserting our results to be equal or better.
