### PR TITLE
Update Defect Density input label based on yield model

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -430,7 +430,7 @@ describe("App", () => {
 					case "Moore's Model":
 					case "Seeds Model":
 						expect(
-							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+							screen.queryByRole("spinbutton", { name: /D0/ }),
 						).toBeInTheDocument();
 						expect(
 							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),
@@ -444,7 +444,7 @@ describe("App", () => {
 						break;
 					case "Bose-Einstein Model":
 						expect(
-							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+							screen.queryByRole("spinbutton", { name: /DD/ }),
 						).toBeInTheDocument();
 						expect(
 							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),
@@ -461,7 +461,7 @@ describe("App", () => {
 							screen.queryByRole("spinbutton", { name: /Yield/ }),
 						).toBeInTheDocument();
 						expect(
-							screen.queryByRole("spinbutton", { name: /Defect Rate/ }),
+							screen.queryByRole("spinbutton", { name: /D0/ }),
 						).not.toBeInTheDocument();
 						expect(
 							screen.queryByRole("spinbutton", { name: /Critical Die Area/ }),

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -508,7 +508,7 @@ function App() {
 							</div>
 							<div className="input-row">
 								<NumberInput
-									label="Defect Rate (#/cm²)"
+									label={selectedModel === "bose-einstein" ? "DD (#/cm²)" : "D0 (#/cm²)"}
 									value={defectRate}
 									min={0}
 									onChange={(event) => setDefectRate(event.target.value)}


### PR DESCRIPTION
## Summary

Closes #14.

Updates the defect density input label from the generic "Defect Rate (#/cm²)" to the industry-standard notation:

- **D0 (#/cm²)** for standard yield models (Poisson, Murphy, Rectangular, Moore, Seeds)
- **DD (#/cm²)** for the Bose-Einstein model

The label dynamically changes when the user selects a different yield model.

## Changes

- `src/components/App.tsx` — conditionally render the label based on `selectedModel`
- `src/components/App.test.tsx` — update test assertions to match the new label names

## Test plan

- [x] All 178 existing unit tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify label reads "D0 (#/cm²)" when Poisson/Murphy/Rectangular/Moore/Seeds is selected
- [ ] Verify label reads "DD (#/cm²)" when Bose-Einstein is selected
- [ ] Verify label is hidden when Manual yield is selected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-label-only change plus test updates; no calculation logic or data flow is modified.
> 
> **Overview**
> Updates the *Defects* section to show an industry-standard defect density label: `D0 (#/cm²)` for non–Bose-Einstein yield models and `DD (#/cm²)` for the `bose-einstein` model (replacing the generic “Defect Rate”).
> 
> Adjusts `App.test.tsx` assertions to match the new accessible label text for each model, including ensuring the defect density field remains hidden for the `manual` model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97590f36da20d1850b93a4db616103cd68e739e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->