### PR TITLE
Add Critical Area unit toggle between mm² and %

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -103,6 +103,7 @@ function App() {
 	const [dieHeight, setDieHeight] = useState<string>("8");
 	const [maintainAspectRatio, setMaintainAspectRatio] = useState(false);
 	const [criticalArea, setCriticalArea] = useState<string>("64");
+	const [criticalAreaUnit, setCriticalAreaUnit] = useState<"mm2" | "percent">("mm2");
 	const [defectRate, setDefectRate] = useState<string>("0.1");
 	const [lossyEdgeWidth, setLossyEdgeWidth] = useState<string>("3");
 	const [notchKeepOutHeight, setNotchKeepOutHeight] = useState<string>("5");
@@ -499,12 +500,48 @@ function App() {
 							</div>
 							<div className="input-row">
 								<NumberInput
-									label="Critical Die Area (mm²)"
-									value={criticalArea}
+									label={`Critical Die Area (${criticalAreaUnit === "mm2" ? "mm²" : "%"})`}
+									value={criticalAreaUnit === "mm2"
+										? criticalArea
+										: `${((parseFloat(criticalArea) / (parseFloat(dieWidth) * parseFloat(dieHeight))) * 100) || 0}`
+									}
 									isDisabled={allCritical}
-									onChange={(event) => setCriticalArea(event.target.value)}
-									max={parseFloat(criticalArea)}
+									onChange={(event) => {
+										if (criticalAreaUnit === "percent") {
+											const percent = Math.min(parseFloat(event.target.value) || 0, 100);
+											const totalDieArea = parseFloat(dieWidth) * parseFloat(dieHeight);
+											setCriticalArea(`${(percent / 100) * totalDieArea}`);
+										} else {
+											setCriticalArea(event.target.value);
+										}
+									}}
+									max={criticalAreaUnit === "mm2" ? (parseFloat(dieWidth) * parseFloat(dieHeight)) || undefined : 100}
+									min={0}
 								/>
+								<fieldset>
+									<div className="radio-group">
+										<label className="radio-item">
+											<input
+												type="radio"
+												name="criticalAreaUnit"
+												checked={criticalAreaUnit === "mm2"}
+												onChange={() => setCriticalAreaUnit("mm2")}
+												disabled={allCritical}
+											/>
+											<span>mm²</span>
+										</label>
+										<label className="radio-item">
+											<input
+												type="radio"
+												name="criticalAreaUnit"
+												checked={criticalAreaUnit === "percent"}
+												onChange={() => setCriticalAreaUnit("percent")}
+												disabled={allCritical}
+											/>
+											<span>%</span>
+										</label>
+									</div>
+								</fieldset>
 							</div>
 							<div className="input-row">
 								<NumberInput


### PR DESCRIPTION
## Summary

Closes #12.

Adds a radio button toggle to switch the Critical Die Area input between absolute area (mm²) and percentage of total die area (%). As suggested by Redfire and noted in the issue, this lets users specify critical area as a percentage, clamped to 100%.

## Changes

- `src/components/App.tsx`
  - Add `criticalAreaUnit` state (`"mm2"` | `"percent"`)
  - Dynamically update the input label to show the active unit
  - Convert between mm² and % for display and input handling
  - Add radio buttons (mm² / %) below the input, using the existing `radio-group` / `radio-item` styling
  - Radio buttons are disabled when "All Die Area Critical" is checked
  - Guard against NaN when die dimensions are temporarily empty

## Test plan

- [x] All 178 existing unit tests pass
- [x] TypeScript type check passes (`tsc --noEmit`)
- [ ] Verify default unit is mm² and input shows absolute area
- [ ] Switch to % and verify value converts correctly (e.g., 64mm² on 8x8 die = 100%)
- [ ] Edit value in % mode and verify it converts back to mm² correctly
- [ ] Verify % is clamped to 100
- [ ] Verify toggle is disabled when "All Die Area Critical" is checked
- [ ] Verify yield calculations remain correct in both modes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change with straightforward unit conversion; main risk is incorrect conversion/edge cases (NaN/empty die dimensions) affecting yield inputs.
> 
> **Overview**
> Adds a `criticalAreaUnit` toggle to the Defects section so the **Critical Die Area** input can be specified as either absolute area (mm²) or as a percentage of total die area.
> 
> Updates the input label, value display, validation bounds, and change handling to convert between % and mm² (clamping % to 100) and disables the unit toggle when **All Die Area Critical** is enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40481c57427f409f8f8c3636e5c212c8b6c05fbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->