### PR TITLE
Improve die placement optimizer

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -42,6 +42,15 @@ describe("App", () => {
 		});
 		const edgeLossInput = screen.getByRole("spinbutton", { name: /Edge Loss/ });
 
+		// Reset translation offsets (auto-optimize may have set non-zero values
+		// before we disabled it)
+		const horizOffsetInput = screen.getByRole("spinbutton", { name: /Reticle Offset Horizontal/ });
+		const vertOffsetInput = screen.getByRole("spinbutton", { name: /Reticle Offset Vertical/ });
+		await user.clear(horizOffsetInput);
+		await user.type(horizOffsetInput, "0");
+		await user.clear(vertOffsetInput);
+		await user.type(vertOffsetInput, "0");
+
 		// Disable Reticle Limit FIRST to allow full panel coverage
 		await user.click(reticleLimitCheckbox);
 		// Remove Edge Loss to count dice to the edge

--- a/src/utils/geometry.ts
+++ b/src/utils/geometry.ts
@@ -175,7 +175,12 @@ function rectangleIsInsideRectangle(
 
 /**
  * Given a circle with the provided diameter, determine the maximum number of
- * rectangles of a given width and height would fit inside it
+ * rectangles of a given width and height would fit inside it.
+ *
+ * Uses a full-grid scan rather than quadrant mirroring. This correctly handles
+ * non-zero offsets where the quadrant approach could miss valid positions near
+ * the circle edge (the old loop range of 0..radius was insufficient when
+ * offsets shifted the grid asymmetrically).
  *
  * @param diameter size of the circle
  * @param rectWidth width of each rectangle
@@ -197,46 +202,39 @@ export function rectanglesInCircle(
 	includePartials: boolean,
 ): Position[] {
 	const radius = diameter / 2;
+	const stepX = rectWidth + gapX;
+	const stepY = rectHeight + gapY;
 	const positions: Position[] = [];
 
-	// Traverse each row, starting at the center
-	for (let y = 0; y <= radius; y += rectHeight + gapY) {
-		// Traverse each column, starting at the center
-		for (let x = 0; x <= radius; x += rectWidth + gapX) {
-			// Draw four rectangles, one in each quadrant (se, sw, nw, ne)
-			for (let i = 0; i < 4; i++) {
-				const rectX = i % 2 === 0 ? x : -x - rectWidth - gapX;
-				const rectY = i % 3 === 0 ? y : -y - rectHeight - gapY;
-				// Apply the offset - used for centering
-				const offsetRectX = rectX + offsetX;
-				const offsetRectY = rectY + offsetY;
-				const corners = getRectCorners(
-					offsetRectX,
-					offsetRectY,
-					rectWidth,
-					rectHeight
-				);
-				const center = getRectCenter(
-					offsetRectX,
-					offsetRectY,
-					rectWidth,
-					rectHeight
-				);
-				const pointsWithinCircle = [...corners, center].filter((point) =>
-					isInsideCircle(point.x, point.y, 0, 0, radius)
-				);
+	// Compute the full range of grid indices whose rectangles could overlap
+	// with the circle. Grid positions are in circle-centered coordinates
+	// (origin at center of circle), then shifted by +radius for output.
+	const minCol = Math.floor((-radius - offsetX - rectWidth) / stepX);
+	const maxCol = Math.ceil((radius - offsetX) / stepX);
+	const minRow = Math.floor((-radius - offsetY - rectHeight) / stepY);
+	const maxRow = Math.ceil((radius - offsetY) / stepY);
 
-				// If partials are allowed, only one point must overlap, otherwise all must.
-				const minOverlappingPoints = includePartials ? 1 : 5;
+	// If partials are allowed, only one point must overlap, otherwise all must.
+	const minOverlappingPoints = includePartials ? 1 : 5;
 
-				// If the rectangle fits within the circle, add it to the result
-				if (pointsWithinCircle.length >= minOverlappingPoints) {
-					positions.push({
-						// Add the radius back to the final coordinates so all are positive integers
-						x: offsetRectX + radius,
-						y: offsetRectY + radius
-					});
-				}
+	for (let row = minRow; row <= maxRow; row++) {
+		for (let col = minCol; col <= maxCol; col++) {
+			const x = col * stepX + offsetX;
+			const y = row * stepY + offsetY;
+
+			const corners = getRectCorners(x, y, rectWidth, rectHeight);
+			const center = getRectCenter(x, y, rectWidth, rectHeight);
+			const pointsWithinCircle = [...corners, center].filter((point) =>
+				isInsideCircle(point.x, point.y, 0, 0, radius)
+			);
+
+			// If the rectangle fits within the circle, add it to the result
+			if (pointsWithinCircle.length >= minOverlappingPoints) {
+				positions.push({
+					// Add the radius back to the final coordinates so all are positive
+					x: x + radius,
+					y: y + radius
+				});
 			}
 		}
 	}

--- a/src/utils/optimization.ts
+++ b/src/utils/optimization.ts
@@ -23,7 +23,11 @@ interface OptimizationResult {
 }
 
 /**
- * Evaluate a single offset configuration and return the number of good dies
+ * Evaluate a single offset configuration and return the number of dies fully
+ * on the wafer (pre-defect). Using goodDies + defectiveDies (i.e. all dies
+ * with 4 corners inside the wafer boundary) rather than post-defect goodDies
+ * gives a more stable objective: defect rounding can make post-defect counts
+ * identical for configurations with different placement quality.
  */
 function evaluateOffset(
 	values: InputValues,
@@ -49,71 +53,138 @@ function evaluateOffset(
 			options.reticleLimit
 		);
 	}
-	return result ? result.goodDies : 0;
+	return result ? result.goodDies + result.defectiveDies : 0;
 }
 
+/**
+ * Perform a grid search over a 2D range of translation offsets,
+ * returning the offset that maximizes good die count.
+ */
+function gridSearch(
+	values: InputValues,
+	options: OptimizationOptions,
+	minX: number,
+	maxX: number,
+	stepX: number,
+	minY: number,
+	maxY: number,
+	stepY: number,
+	bestSoFar: OptimizationResult
+): OptimizationResult {
+	let { maxGoodDies, optimalTransHoriz, optimalTransVert } = bestSoFar;
+
+	for (let transVert = minY; transVert <= maxY; transVert += stepY) {
+		for (let transHoriz = minX; transHoriz <= maxX; transHoriz += stepX) {
+			const testValues: InputValues = {
+				...values,
+				transHoriz: parseFloat(transHoriz.toFixed(4)),
+				transVert: parseFloat(transVert.toFixed(4))
+			};
+
+			const goodDies = evaluateOffset(testValues, options);
+
+			if (goodDies > maxGoodDies) {
+				maxGoodDies = goodDies;
+				optimalTransHoriz = testValues.transHoriz;
+				optimalTransVert = testValues.transVert;
+			}
+		}
+	}
+
+	return { maxGoodDies, optimalTransHoriz, optimalTransVert };
+}
+
+/**
+ * Compute the search period for optimization based on the placement mode.
+ *
+ * In reticle-limited mode, the shot grid has period equal to the trimmed
+ * field dimensions (dies packed into the reticle with waste trimmed). The
+ * old algorithm searched only ±0.5×dieWidth, which for small dies in large
+ * reticle fields covered as little as 8% of the actual period.
+ *
+ * In non-reticle mode, the effective period is the die pitch.
+ */
+function getSearchPeriod(
+	values: InputValues,
+	options: OptimizationOptions
+): { periodX: number; periodY: number } {
+	const diePitchX = values.dieWidth + values.scribeHoriz;
+	const diePitchY = values.dieHeight + values.scribeVert;
+
+	if (options.reticleLimit) {
+		// Trimmed field width = numCols × diePitch (shot waste removed)
+		const numCols = Math.floor(options.fieldWidth / diePitchX);
+		const numRows = Math.floor(options.fieldHeight / diePitchY);
+		return {
+			periodX: Math.max(diePitchX, numCols * diePitchX),
+			periodY: Math.max(diePitchY, numRows * diePitchY)
+		};
+	}
+
+	return { periodX: diePitchX, periodY: diePitchY };
+}
+
+/**
+ * Three-stage optimization to find the translation offset that maximizes
+ * the number of good dies on a wafer or panel.
+ *
+ * Improvements over the previous two-stage approach:
+ * 1. Correct search period: uses shot pitch for reticle-limited mode instead
+ *    of die pitch, covering the full optimization space.
+ * 2. Adaptive step sizes: scales with the period so both tiny (2mm) and
+ *    large (68mm) dies get appropriate resolution.
+ * 3. Three stages: coarse (full period) → fine (±1 coarse step) →
+ *    ultra-fine (±1 fine step), reaching ~16μm precision for typical dies.
+ */
 export function optimizeDieOffset(
 	values: InputValues,
 	options: OptimizationOptions
 ): OptimizationResult {
-	const { dieWidth, dieHeight } = values;
+	const { periodX, periodY } = getSearchPeriod(values, options);
 
-	let maxGoodDies = 0;
-	let optimalTransHoriz = values.transHoriz;
-	let optimalTransVert = values.transVert;
+	// ~25 steps per dimension keeps each stage at ~625 evaluations
+	const stepsPerDim = 25;
+	const coarseStepX = Math.max(0.01, periodX / stepsPerDim);
+	const coarseStepY = Math.max(0.01, periodY / stepsPerDim);
 
-	// Stage 1: Coarse grid search with 0.5mm step. Go from minus die width/height
-	// to plus die width/height
-	const coarseStep = 0.5;
-
-	for (let transVert = -0.5 * dieHeight; transVert <= 0.5 * dieHeight; transVert += coarseStep) {
-		for (let transHoriz = -0.5 * dieWidth; transHoriz <= 0.5 * dieWidth; transHoriz += coarseStep) {
-			const testValues: InputValues = {
-				...values,
-				transHoriz: parseFloat(transHoriz.toFixed(3)),
-				transVert: parseFloat(transVert.toFixed(3))
-			};
-
-			const goodDies = evaluateOffset(testValues, options);
-
-			if (goodDies > maxGoodDies) {
-				maxGoodDies = goodDies;
-				optimalTransHoriz = testValues.transHoriz;
-				optimalTransVert = testValues.transVert;
-			}
-		}
-	}
-
-	// Stage 2: Fine grid search with 0.1mm step around coarse optimum
-	const fineStep = 0.1;
-	const fineRadius = 1;
-
-	const fineHorizMin = optimalTransHoriz - fineRadius;
-	const fineHorizMax = optimalTransHoriz + fineRadius;
-	const fineVertMin = optimalTransVert - fineRadius;
-	const fineVertMax = optimalTransVert + fineRadius;
-
-	for (let transVert = fineVertMin; transVert <= fineVertMax; transVert += fineStep) {
-		for (let transHoriz = fineHorizMin; transHoriz <= fineHorizMax; transHoriz += fineStep) {
-			const testValues: InputValues = {
-				...values,
-				transHoriz: parseFloat(transHoriz.toFixed(3)),
-				transVert: parseFloat(transVert.toFixed(3))
-			};
-
-			const goodDies = evaluateOffset(testValues, options);
-
-			if (goodDies > maxGoodDies) {
-				maxGoodDies = goodDies;
-				optimalTransHoriz = testValues.transHoriz;
-				optimalTransVert = testValues.transVert;
-			}
-		}
-	}
-
-	return {
-		optimalTransHoriz,
-		optimalTransVert,
-		maxGoodDies
+	// Seed the search with the current offset so the optimizer always
+	// returns a result at least as good as the starting position
+	const initialGoodDies = evaluateOffset(values, options);
+	let best: OptimizationResult = {
+		maxGoodDies: initialGoodDies,
+		optimalTransHoriz: values.transHoriz,
+		optimalTransVert: values.transVert
 	};
+
+	// Stage 1: Coarse search over one full period
+	best = gridSearch(
+		values, options,
+		-periodX / 2, periodX / 2, coarseStepX,
+		-periodY / 2, periodY / 2, coarseStepY,
+		best
+	);
+
+	// Stage 2: Fine search - ±1 coarse step around the coarse optimum
+	const fineStepX = coarseStepX / 5;
+	const fineStepY = coarseStepY / 5;
+
+	best = gridSearch(
+		values, options,
+		best.optimalTransHoriz - coarseStepX, best.optimalTransHoriz + coarseStepX, fineStepX,
+		best.optimalTransVert - coarseStepY, best.optimalTransVert + coarseStepY, fineStepY,
+		best
+	);
+
+	// Stage 3: Ultra-fine search - ±1 fine step around the fine optimum
+	const ultraFineStepX = fineStepX / 5;
+	const ultraFineStepY = fineStepY / 5;
+
+	best = gridSearch(
+		values, options,
+		best.optimalTransHoriz - fineStepX, best.optimalTransHoriz + fineStepX, ultraFineStepX,
+		best.optimalTransVert - fineStepY, best.optimalTransVert + fineStepY, ultraFineStepY,
+		best
+	);
+
+	return best;
 }


### PR DESCRIPTION
## Summary
- **Full-grid scan** in `rectanglesInCircle`: replaces quadrant-mirroring approach that missed valid shot positions when the optimizer applied non-zero offsets near the wafer edge
- **Period-aware search range** for reticle-limited mode: searches over the full trimmed field pitch instead of die pitch (the old range covered as little as 8% of the search space for small dies in large reticle fields)
- **Three-stage adaptive search** (coarse → fine → ultra-fine) with ~16μm precision, replacing the fixed 0.5mm/0.1mm two-stage approach
- **Better optimization objective**: maximizes pre-defect full dies instead of post-defect good dies, avoiding yield-model rounding artifacts that made the objective flat for large dies with low yields

## Test plan
- [x] All 178 existing tests pass (geometry, calculations, optimization benchmarks, App component)
- [x] All 7 Silicon Edge DYC benchmarks continue to match or beat reference values
- [ ] Manual verification: compare die counts for small dies (2-3mm) with reticle limit enabled vs previous version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core geometry placement and offset-optimization algorithms, which can materially alter die counts and performance across wafer/panel scenarios. Risk is moderate due to expanded search space and updated objective function affecting results and runtime.
> 
> **Overview**
> Improves die placement optimization to avoid missing valid placements and to search offsets more effectively, especially with non-zero translation offsets and reticle-limited mode.
> 
> `rectanglesInCircle` switches from quadrant mirroring to a full-grid scan with computed row/col bounds so offset grids near the wafer edge are evaluated correctly. `optimizeDieOffset` now maximizes *pre-defect full dies* (`goodDies + defectiveDies`), uses a period-aware search range (trimmed reticle pitch vs die pitch), and replaces the fixed two-stage search with a 3-stage adaptive grid search (coarse→fine→ultra-fine) seeded from the current offset.
> 
> Updates `App.test.tsx` to explicitly reset translation offsets to `0` after disabling auto-optimize to keep the panel die-count test deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b9371a2a237203eec27c0548abf294ae07dcf3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->