### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/die-yield-calculator.php
+++ b/die-yield-calculator.php
@@ -4,7 +4,7 @@
  * Description:       Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.
  * Requires at least: 6.6
  * Requires PHP:      7.0
- * Version:           0.4.3
+ * Version:           0.5.0
  * Author:            SemiAnalysis
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "die-yield-calculator-wp",
-			"version": "0.4.3",
+			"version": "0.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "die-yield-calculator-wp",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"description": "Gutenberg block for embedding the SemiAnalysis die yield calculator React application in posts and pages.",
 	"author": "SemiAnalysis",
 	"license": "GPL-2.0-or-later",

--- a/src/block.json
+++ b/src/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "create-block/die-yield-calculator",
-	"version": "0.4.3",
+	"version": "0.5.0",
 	"title": "Die Yield Calculator",
 	"category": "widgets",
 	"icon": "calculator",


### PR DESCRIPTION
## Summary
- Bumps plugin version from 0.4.3 to 0.5.0 in die-yield-calculator.php, package.json, src/block.json, and package-lock.json
- Plugin has already been deployed to production

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata-only version bump with no functional or dependency changes beyond updating version fields.
> 
> **Overview**
> Bumps the Die Yield Calculator plugin/package version from `0.4.3` to `0.5.0` across the WordPress plugin header, `package.json`, `package-lock.json`, and `src/block.json` so the release version stays consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c93877d739d92cc4a876cc06b2d12043d82f996. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->